### PR TITLE
fix: correct statusline hostname mapping for 101/105

### DIFF
--- a/claude/statusline-command.sh
+++ b/claude/statusline-command.sh
@@ -9,8 +9,8 @@ dir=$(basename "$(pwd)")
 case "$raw_host" in
   JackonYangs-MacBook-Pro) host="mac" ;;
   iZ25e9yr8voZ)            host="jackon.me" ;;
-  aigcic-ai)               host="101" ;;
-  aig-a100)                host="105" ;;
+  aigcic-ai)               host="105" ;;
+  aig-a100)                host="101" ;;
   aigcic-h3c-01)           host="116" ;;
   *) host="$raw_host" ;;
 esac


### PR DESCRIPTION
## Summary
- swap the two case branches in claude/statusline-command.sh so aig-a100 maps to "101" and aigcic-ai maps to "105"

Closes #29

## Test plan
- [ ] verify on 101: ssh 101, start CC, statusline shows jiekun.yang@101
- [ ] verify on 105: ssh 105, start CC, statusline shows jiekun.yang@105

🤖 Generated with [Claude Code](https://claude.com/claude-code)