### PR TITLE
feat: cross-llm-review skill — copilot CLI second opinion (#17)

### DIFF
--- a/claude/skills/cross-llm-review/SKILL.md
+++ b/claude/skills/cross-llm-review/SKILL.md
@@ -114,3 +114,14 @@ needed — once this directory is in the repo, `./setup.sh` on each of the 5
 machines picks it up.
 
 Per-machine prerequisite: `copilot` CLI installed and authenticated.
+
+## Known v0 limitations (followup)
+
+- **ARG_MAX on huge PRs.** The PR bundle is inlined into the prompt and
+  passed via `-p "$(cat ./prompt.md)"`. On macOS `getconf ARG_MAX` ≈ 256KB;
+  on Linux usually 2MB. PRs whose bundle exceeds the local limit will be
+  truncated or rejected by the shell with no friendly error. Followup is to
+  switch to a stdin-fed prompt form or a copilot CLI flag that reads the
+  prompt from a file. Not fixed in v0 because every PR exercised so far is
+  well under the limit; raised by the meta-dogfood self-review of #23.
+

--- a/claude/skills/cross-llm-review/SKILL.md
+++ b/claude/skills/cross-llm-review/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: cross-llm-review
+description: Second-opinion PR review via GitHub Copilot CLI (gpt-4.1) — runs in an isolated cwd to keep the cross-model verdict free from local CLAUDE.md/AGENTS.md contamination.
+---
+
+# cross-llm-review
+
+A different model family looks at the same PR Claude just looked at, and tells
+you what Claude probably missed. Uses GitHub Copilot CLI (gpt-4.1, free tier)
+under hard isolation so the second opinion is actually a second opinion.
+
+Tracks issue: claude-conf #17.
+
+## When to use
+
+- Architectural / direction calls where Claude's verdict is load-bearing
+- PRs touching auth, payments, migrations, anything where a blind spot is expensive
+- When Claude's review feels too tidy and you suspect bias from same-model self-checking
+- Before merging your own work after Claude reviewed it
+
+Skip for: trivial fixes, doc-only changes, single-line config updates. The
+free-tier latency (~40-100s) isn't worth it for low-stakes changes.
+
+## Hard contract — DO NOT relax
+
+These three flags exist because each one fixed a real pollution incident.
+Removing any of them silently breaks the "independent second opinion" property:
+
+- `--no-custom-instructions` — blocks AGENTS.md / CLAUDE.md auto-load. Without
+  it, copilot picks up whatever instruction file lives in cwd and answers as
+  that project's agent rather than as a neutral reviewer.
+- `--disable-builtin-mcps` — disables `github-mcp-server`. Without it, copilot
+  has cross-repo write access and has been observed making real changes
+  (writing to dispatches.yaml in waypoint cwd) just to satisfy a probe prompt.
+- Isolated cwd (`/tmp/cross-llm-review/<label>/`) — even with the two flags
+  above, cwd determines what tools are anchored where. We always cd into a
+  fresh empty dir before invoking copilot.
+
+If you find yourself thinking "but for *this* case I just want to skip
+isolation to save 2 seconds" — stop. That defeats the entire point of the
+skill. Either run it properly or don't run it.
+
+## Usage
+
+```bash
+# Review a PR in another repo:
+~/.claude/skills/cross-llm-review/bin/cross-llm-review.sh owner/repo#123
+
+# Review a PR in the current repo:
+~/.claude/skills/cross-llm-review/bin/cross-llm-review.sh 123
+
+# Save the review to a file as well as stdout:
+~/.claude/skills/cross-llm-review/bin/cross-llm-review.sh owner/repo#123 --out review.md
+
+# Use a stronger (premium-quota) model for high-stakes calls:
+~/.claude/skills/cross-llm-review/bin/cross-llm-review.sh owner/repo#123 --model gpt-5.4
+
+# Debug: keep the isolation dir for inspection
+~/.claude/skills/cross-llm-review/bin/cross-llm-review.sh owner/repo#123 --keep-iso
+```
+
+Output is markdown with sections: Summary / Concerns / Questions for the
+author / What looks good. A trailing italic line records premiumRequests, API
+duration, and session duration.
+
+## Model selection
+
+- `gpt-4.1` (default) — `premiumRequests=0`, free under Copilot subscription.
+  Latency 40-100s for a moderate PR. Use for the common case.
+- `gpt-5.x` — premium quota. Reserve for high-stakes architecture calls or
+  when gpt-4.1 produced something obviously shallow and you want to escalate.
+
+## How it works
+
+1. `gh pr view` + `gh pr diff` build a markdown bundle (metadata + description + diff).
+2. Bundle is **inlined into the prompt** — not passed as a file reference.
+   Copilot in `-p` mode does not proactively use read tools and will hallucinate
+   a fictional PR if you ask it to "read ./pr-bundle.md". Inlining is the only
+   way to guarantee the model sees the real diff. (Discovered the hard way
+   during dogfood — see `samples/waypoint-pr-15.md` for the working version.)
+3. `copilot` runs in a fresh `/tmp/cross-llm-review/<ts>-<pid>/` cwd with the
+   isolation flags above.
+4. JSONL output is parsed; the final `assistant.message` content is printed.
+5. Isolation dir is removed unless `--keep-iso`.
+
+## Error modes
+
+| Symptom                              | Likely cause                          | Fix                                |
+| ------------------------------------ | ------------------------------------- | ---------------------------------- |
+| `copilot CLI not found`              | binary not installed / not in PATH    | install via `gh extension` or copilot docs |
+| `failed to fetch PR metadata`        | wrong ref, no auth, private repo      | `gh auth status` / verify ref      |
+| `copilot exited with status N` + auth msg | OAuth token expired              | `copilot login`                    |
+| Output is generic / hallucinated     | bundle didn't reach the prompt        | run with `--keep-iso`, inspect `prompt.md` |
+| Output mentions code not in the diff | model fabrication (rare with inline)  | re-run; if persists, escalate model |
+
+## Dogfood evidence
+
+- `samples/waypoint-pr-15.md` — review of `JackonYang/waypoint#15` (ledger as
+  shared context). Real lines quoted from CLAUDE.md and dispatch-table.md;
+  identifies enforcement gap, unbounded archive read, network-dependency
+  fragility. premiumRequests=0, 101s API.
+
+## Non-goals
+
+- Not for CI-failure debugging (different surface — see AICASimPlatform #147)
+- Not a BYOK multi-provider abstraction (v0 = copilot only)
+- Not a replacement for Claude's review — it's a second opinion, run after
+
+## Deployment
+
+Symlinked into `~/.claude/skills/cross-llm-review/` by `setup.sh` (which
+already symlinks the entire `claude/skills/` directory). No setup.sh changes
+needed — once this directory is in the repo, `./setup.sh` on each of the 5
+machines picks it up.
+
+Per-machine prerequisite: `copilot` CLI installed and authenticated.

--- a/claude/skills/cross-llm-review/bin/cross-llm-review.sh
+++ b/claude/skills/cross-llm-review/bin/cross-llm-review.sh
@@ -101,15 +101,24 @@ PR_META_JSON="$ISO_DIR/pr-meta.json"
 PR_DIFF="$ISO_DIR/pr.diff"
 PR_BUNDLE="$ISO_DIR/pr-bundle.md"
 
+# gh stderr is captured to a file and surfaced on failure rather than
+# discarded — auth/network/permission errors need to reach the caller, a
+# generic "failed to fetch" with no underlying message is undebuggable.
+GH_META_ERR="$ISO_DIR/gh-meta.err"
 if ! gh pr view "$PR_NUM" "${GH_REPO_FLAG[@]}" \
        --json number,title,body,author,baseRefName,headRefName,state,url,additions,deletions,changedFiles \
-       > "$PR_META_JSON" 2>/dev/null; then
+       > "$PR_META_JSON" 2> "$GH_META_ERR"; then
   echo "failed to fetch PR metadata for $PR_REF" >&2
+  echo "--- gh stderr ---" >&2
+  cat "$GH_META_ERR" >&2
   exit 4
 fi
 
-if ! gh pr diff "$PR_NUM" "${GH_REPO_FLAG[@]}" > "$PR_DIFF" 2>/dev/null; then
+GH_DIFF_ERR="$ISO_DIR/gh-diff.err"
+if ! gh pr diff "$PR_NUM" "${GH_REPO_FLAG[@]}" > "$PR_DIFF" 2> "$GH_DIFF_ERR"; then
   echo "failed to fetch PR diff for $PR_REF" >&2
+  echo "--- gh stderr ---" >&2
+  cat "$GH_DIFF_ERR" >&2
   exit 4
 fi
 

--- a/claude/skills/cross-llm-review/bin/cross-llm-review.sh
+++ b/claude/skills/cross-llm-review/bin/cross-llm-review.sh
@@ -19,6 +19,16 @@
 
 set -euo pipefail
 
+# ─── PATH augmentation ──────────────────────────────────
+# This script is meant to be self-contained: callable from cron, launchd,
+# systemd --user, butler dispatch, or any other context where PATH may not
+# include Homebrew or local bin dirs. Augment PATH with the standard
+# Homebrew locations on both macOS arch flavors and Linuxbrew, plus the
+# usual local bins. We append rather than prepend so the caller's PATH
+# still wins for any binary they care to override.
+PATH="${PATH:-/usr/bin:/bin}:/opt/homebrew/bin:/usr/local/bin:/home/linuxbrew/.linuxbrew/bin:$HOME/.local/bin"
+export PATH
+
 PR_REF=""
 MODEL="gpt-4.1"
 OUT_FILE=""
@@ -215,11 +225,19 @@ RAW_OUT="$ISO_DIR/copilot.jsonl"
 }
 
 # ─── parse JSONL → final markdown ───────────────────────
+# IMPORTANT: if no assistant.message is present (quota exhausted, rate
+# limit, copilot returned only an error event, malformed JSONL, etc.) we
+# MUST exit non-zero. A successful exit with a placeholder string would
+# let callers (butler, CI, humans) treat a failed review as if it had
+# succeeded — the entire point of this skill is the verdict, so a missing
+# verdict is a hard failure.
+set +e
 REVIEW_MD="$(python3 - "$RAW_OUT" <<'PY'
 import json, sys
 path = sys.argv[1]
 last_msg = None
 usage = None
+errors = []
 with open(path) as f:
     for line in f:
         line = line.strip()
@@ -229,17 +247,25 @@ with open(path) as f:
             obj = json.loads(line)
         except json.JSONDecodeError:
             continue
-        t = obj.get("type")
+        t = obj.get("type", "")
         if t == "assistant.message":
             content = obj.get("data", {}).get("content")
             if content:
                 last_msg = content
         elif t == "result":
             usage = obj.get("usage", {})
+        elif "error" in t.lower() or obj.get("data", {}).get("error"):
+            errors.append(obj)
 
 if not last_msg:
-    print("(no assistant message in copilot output)")
-    sys.exit(0)
+    sys.stderr.write("cross-llm-review: copilot returned no assistant message\n")
+    if errors:
+        sys.stderr.write("--- copilot error events ---\n")
+        for e in errors[:5]:
+            sys.stderr.write(json.dumps(e)[:500] + "\n")
+    else:
+        sys.stderr.write("(no error events in JSONL either — likely quota exhausted, rate limited, or malformed output)\n")
+    sys.exit(6)
 
 print(last_msg.rstrip())
 print()
@@ -251,6 +277,15 @@ if usage:
     print(f"_cross-llm-review · model: see invocation · premiumRequests: {pr} · api: {api_ms}ms · session: {sess_ms}ms_")
 PY
 )"
+PARSE_STATUS=$?
+set -e
+
+if [[ $PARSE_STATUS -ne 0 ]]; then
+  echo "$REVIEW_MD" >&2
+  echo "" >&2
+  echo "Raw JSONL kept for debugging: re-run with --keep-iso to inspect $ISO_DIR/copilot.jsonl" >&2
+  exit "$PARSE_STATUS"
+fi
 
 if [[ -n "$OUT_FILE" ]]; then
   printf '%s\n' "$REVIEW_MD" > "$OUT_FILE"

--- a/claude/skills/cross-llm-review/bin/cross-llm-review.sh
+++ b/claude/skills/cross-llm-review/bin/cross-llm-review.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+# cross-llm-review — second-opinion PR review via GitHub Copilot CLI (gpt-4.1).
+#
+# Why this exists: Claude reviewing Claude's own work shares the same biases.
+# This wrapper invokes a different model family (OpenAI via Copilot CLI) on
+# the same diff, isolated from any local CLAUDE.md / AGENTS.md context that
+# could pollute the second opinion.
+#
+# Hard isolation contract (do NOT relax):
+#   --no-custom-instructions   block AGENTS.md / CLAUDE.md auto-load
+#   --disable-builtin-mcps     disable github-mcp-server (cross-repo pollution source)
+#   cwd is a fresh /tmp dir    nothing in cwd except the diff bundle we put there
+#
+# Usage:
+#   cross-llm-review.sh <owner/repo#N> [--model gpt-4.1] [--out FILE] [--keep-iso]
+#   cross-llm-review.sh <N>            (uses current repo from gh)
+#
+# Output: markdown review on stdout. Exit 0 on success, non-zero on failure.
+
+set -euo pipefail
+
+PR_REF=""
+MODEL="gpt-4.1"
+OUT_FILE=""
+KEEP_ISO=false
+
+usage() {
+  sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'
+  exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --model)    MODEL="$2"; shift 2 ;;
+    --out)      OUT_FILE="$2"; shift 2 ;;
+    --keep-iso) KEEP_ISO=true; shift ;;
+    -h|--help)  usage ;;
+    -*)         echo "unknown flag: $1" >&2; exit 2 ;;
+    *)          PR_REF="$1"; shift ;;
+  esac
+done
+
+[[ -z "$PR_REF" ]] && { echo "missing PR ref" >&2; usage; }
+
+# ─── parse PR ref ───────────────────────────────────────
+# Forms: owner/repo#N  |  N (current repo)
+if [[ "$PR_REF" == *"#"* ]]; then
+  REPO="${PR_REF%#*}"
+  PR_NUM="${PR_REF#*#}"
+  GH_REPO_FLAG=(-R "$REPO")
+else
+  REPO=""
+  PR_NUM="$PR_REF"
+  GH_REPO_FLAG=()
+fi
+
+if ! [[ "$PR_NUM" =~ ^[0-9]+$ ]]; then
+  echo "invalid PR number: $PR_NUM" >&2; exit 2
+fi
+
+# ─── preflight ──────────────────────────────────────────
+# Resolve copilot binary. The interactive shell aliases `copilot` to its real
+# path; that alias doesn't propagate to bash subshells, so look for the binary
+# directly with a fallback to the known install location.
+COPILOT_BIN="$(command -v copilot 2>/dev/null || true)"
+if [[ -z "$COPILOT_BIN" || ! -x "$COPILOT_BIN" ]]; then
+  for cand in "$HOME/.local/share/gh/copilot/copilot" "/usr/local/bin/copilot"; do
+    if [[ -x "$cand" ]]; then COPILOT_BIN="$cand"; break; fi
+  done
+fi
+[[ -x "$COPILOT_BIN" ]] || { echo "copilot CLI not found in PATH or ~/.local/share/gh/copilot/" >&2; exit 3; }
+
+command -v gh      >/dev/null || { echo "gh CLI not installed" >&2; exit 3; }
+command -v python3 >/dev/null || { echo "python3 required for JSONL parsing" >&2; exit 3; }
+
+# ─── fetch PR context ───────────────────────────────────
+TMP_LABEL="$(date +%s)-$$"
+ISO_DIR="/tmp/cross-llm-review/${TMP_LABEL}"
+mkdir -p "$ISO_DIR"
+
+cleanup() {
+  if ! $KEEP_ISO; then
+    rm -rf "$ISO_DIR"
+  else
+    echo "[cross-llm-review] kept isolation dir: $ISO_DIR" >&2
+  fi
+}
+trap cleanup EXIT
+
+PR_META_JSON="$ISO_DIR/pr-meta.json"
+PR_DIFF="$ISO_DIR/pr.diff"
+PR_BUNDLE="$ISO_DIR/pr-bundle.md"
+
+if ! gh pr view "$PR_NUM" "${GH_REPO_FLAG[@]}" \
+       --json number,title,body,author,baseRefName,headRefName,state,url,additions,deletions,changedFiles \
+       > "$PR_META_JSON" 2>/dev/null; then
+  echo "failed to fetch PR metadata for $PR_REF" >&2
+  exit 4
+fi
+
+if ! gh pr diff "$PR_NUM" "${GH_REPO_FLAG[@]}" > "$PR_DIFF" 2>/dev/null; then
+  echo "failed to fetch PR diff for $PR_REF" >&2
+  exit 4
+fi
+
+# ─── build context bundle ───────────────────────────────
+python3 - "$PR_META_JSON" "$PR_DIFF" "$PR_BUNDLE" <<'PY'
+import json, sys, pathlib
+meta_path, diff_path, out_path = sys.argv[1:]
+meta = json.loads(pathlib.Path(meta_path).read_text())
+diff = pathlib.Path(diff_path).read_text()
+
+out = []
+out.append(f"# PR #{meta['number']}: {meta['title']}")
+out.append("")
+out.append(f"- URL: {meta['url']}")
+out.append(f"- State: {meta['state']}")
+out.append(f"- Author: {meta['author']['login']}")
+out.append(f"- Branch: {meta['headRefName']} -> {meta['baseRefName']}")
+out.append(f"- Files changed: {meta['changedFiles']}  (+{meta['additions']} / -{meta['deletions']})")
+out.append("")
+out.append("## Description")
+out.append("")
+out.append((meta.get('body') or '*(no description)*').strip())
+out.append("")
+out.append("## Diff")
+out.append("")
+out.append("```diff")
+out.append(diff.rstrip())
+out.append("```")
+pathlib.Path(out_path).write_text("\n".join(out))
+PY
+
+# ─── build prompt (bundle is INLINED — copilot in -p mode does not
+#     proactively use read tools, so file references get hallucinated). ──
+PROMPT_FILE="$ISO_DIR/prompt.md"
+{
+  cat <<'PROMPT_HEAD'
+You are a senior code reviewer providing a SECOND OPINION on a pull request
+that another AI reviewer has already looked at. Your job is to be a useful
+skeptic — find what the first reviewer might have missed.
+
+Below is the full PR bundle. Read it carefully — do NOT invent code or
+filenames that are not present in the diff. If the diff is small or obvious,
+say so plainly rather than padding.
+
+Produce a review with these sections:
+
+## Summary
+One paragraph on what this PR actually does, in your own words.
+
+## Concerns
+For each concern, quote the exact file path and a few diff lines you are
+reacting to, then explain the risk. Focus on:
+- Correctness bugs (off-by-one, null/nil, race, ordering)
+- API / contract changes (breaking callers, silent behavior shifts)
+- Security (injection, auth, secrets, untrusted input)
+- Edge cases not handled (empty input, large input, error paths)
+- Performance traps (N+1, unbounded growth, sync I/O in hot path)
+Omit any category where you have nothing real to say.
+
+## Questions for the author
+Specific questions whose answers would change your assessment. Be concrete —
+no "did you add tests?" filler.
+
+## What looks good
+Brief. Only mention things that show real care, not generic praise.
+
+Rules:
+- Quote actual lines from the diff below. Do NOT fabricate code.
+- If the diff is trivial, say so and stop — do not invent concerns.
+- Do not summarize the PR description back to me. Add value beyond it.
+- Output markdown only. No preamble, no sign-off.
+
+=== BEGIN PR BUNDLE ===
+
+PROMPT_HEAD
+  cat "$PR_BUNDLE"
+  cat <<'PROMPT_TAIL'
+
+=== END PR BUNDLE ===
+
+Begin your review now.
+PROMPT_TAIL
+} > "$PROMPT_FILE"
+
+# ─── invoke copilot in isolated cwd ─────────────────────
+RAW_OUT="$ISO_DIR/copilot.jsonl"
+
+# CRITICAL: cd into the isolated dir. Do NOT run copilot from the calling cwd.
+(
+  cd "$ISO_DIR"
+  "$COPILOT_BIN" \
+    --model "$MODEL" \
+    --no-custom-instructions \
+    --disable-builtin-mcps \
+    --no-ask-user \
+    --silent \
+    --output-format json \
+    --allow-all-tools \
+    --allow-all-paths \
+    -p "$(cat ./prompt.md)" \
+    > "$RAW_OUT" 2>&1
+) || {
+  status=$?
+  echo "copilot exited with status $status. Last 20 lines of output:" >&2
+  tail -20 "$RAW_OUT" >&2
+  if grep -q '"error"' "$RAW_OUT" 2>/dev/null; then
+    if grep -qi 'auth' "$RAW_OUT"; then
+      echo "" >&2
+      echo "Hint: copilot auth may be expired. Try: copilot login" >&2
+    fi
+  fi
+  exit 5
+}
+
+# ─── parse JSONL → final markdown ───────────────────────
+REVIEW_MD="$(python3 - "$RAW_OUT" <<'PY'
+import json, sys
+path = sys.argv[1]
+last_msg = None
+usage = None
+with open(path) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        t = obj.get("type")
+        if t == "assistant.message":
+            content = obj.get("data", {}).get("content")
+            if content:
+                last_msg = content
+        elif t == "result":
+            usage = obj.get("usage", {})
+
+if not last_msg:
+    print("(no assistant message in copilot output)")
+    sys.exit(0)
+
+print(last_msg.rstrip())
+print()
+print("---")
+if usage:
+    pr = usage.get("premiumRequests", "?")
+    api_ms = usage.get("totalApiDurationMs", 0)
+    sess_ms = usage.get("sessionDurationMs", 0)
+    print(f"_cross-llm-review · model: see invocation · premiumRequests: {pr} · api: {api_ms}ms · session: {sess_ms}ms_")
+PY
+)"
+
+if [[ -n "$OUT_FILE" ]]; then
+  printf '%s\n' "$REVIEW_MD" > "$OUT_FILE"
+fi
+printf '%s\n' "$REVIEW_MD"

--- a/claude/skills/cross-llm-review/samples/self-review-pr-23.md
+++ b/claude/skills/cross-llm-review/samples/self-review-pr-23.md
@@ -1,0 +1,77 @@
+## Summary
+
+This PR introduces a new skill, `cross-llm-review`, which wraps the GitHub Copilot CLI to provide an isolated, independent second-opinion PR review using GPT-4.1. It ensures hard isolation from local context (e.g., CLAUDE.md/AGENTS.md) and disables cross-repo pollution, with clear documentation and a sample review included.
+
+## Concerns
+
+### `claude/skills/cross-llm-review/bin/cross-llm-review.sh`
+> ```diff
+> +  "$COPILOT_BIN" \
+> +    --model "$MODEL" \
+> +    --no-custom-instructions \
+> +    --disable-builtin-mcps \
+> +    --no-ask-user \
+> +    --silent \
+> +    --output-format json \
+> +    --allow-all-tools \
+> +    --allow-all-paths \
+> +    -p "$(cat ./prompt.md)" \
+> +    > "$RAW_OUT" 2>&1
+> ```
+
+- **Risk:** The script passes the entire prompt via `-p "$(cat ./prompt.md)"`. If the PR bundle is very large, this could hit shell or copilot CLI argument length limits, potentially truncating the prompt and causing incomplete reviews. There is no explicit check or warning for prompt size.
+
+> ```diff
+> +if ! gh pr view "$PR_NUM" "${GH_REPO_FLAG[@]}" \
+> +       --json number,title,body,author,baseRefName,headRefName,state,url,additions,deletions,changedFiles \
+> +       > "$PR_META_JSON" 2>/dev/null; then
+> +  echo "failed to fetch PR metadata for $PR_REF" >&2
+> +  exit 4
+> +fi
+> ```
+
+- **Risk:** The script suppresses all `gh` CLI errors (`2>/dev/null`), which could make debugging harder if the underlying issue is authentication, network, or permissions. The user only sees a generic failure message.
+
+> ```diff
+> +trap cleanup EXIT
+> +...
+> +if ! $KEEP_ISO; then
+> +  rm -rf "$ISO_DIR"
+> +else
+> +  echo "[cross-llm-review] kept isolation dir: $ISO_DIR" >&2
+> +fi
+> ```
+
+- **Risk:** If the script is interrupted (e.g., with SIGKILL), the isolation directory may not be cleaned up, leading to orphaned `/tmp/cross-llm-review/*` directories over time. This is a minor resource leak.
+
+### `claude/skills/cross-llm-review/SKILL.md`
+> ```diff
+> +- `--no-custom-instructions` — blocks AGENTS.md / CLAUDE.md auto-load. Without
+> +  it, copilot picks up whatever instruction file lives in cwd and answers as
+> +  that project's agent rather than as a neutral reviewer.
+> +...
+> +- `--disable-builtin-mcps` — disables `github-mcp-server`. Without it, copilot
+> +  has cross-repo write access and has been observed making real changes
+> +  (writing to dispatches.yaml in waypoint cwd) just to satisfy a probe prompt.
+> +...
+> +Per-machine prerequisite: `copilot` CLI installed and authenticated.
+> ```
+
+- **Risk:** The documentation is clear about the need for isolation, but the script does not check for or warn about a running `github-mcp-server` process outside the isolated environment, which could still pose a risk if the Copilot CLI changes its behavior in future versions.
+
+## Questions for the author
+
+1. Have you observed any prompt truncation or failures when reviewing very large PRs? If so, is there a mitigation plan?
+2. Is there a reason for suppressing all `gh` CLI error output, rather than surfacing it to the user for debugging?
+3. Should there be a periodic cleanup mechanism for `/tmp/cross-llm-review/` in case of orphaned directories from interrupted runs?
+4. Have you tested with Copilot CLI versions beyond the current one to ensure the isolation flags remain effective?
+
+## What looks good
+
+- The isolation contract is well-documented and strictly enforced in the script.
+- The prompt inlining approach is justified with real-world evidence, avoiding hallucinated reviews.
+- The sample review demonstrates grounded, high-signal output, quoting real diff lines and surfacing nuanced risks.
+- The script is defensive about tool presence and provides actionable error hints (e.g., for Copilot auth).
+
+---
+_cross-llm-review · model: see invocation · premiumRequests: 0 · api: 56464ms · session: 58664ms_

--- a/claude/skills/cross-llm-review/samples/waypoint-pr-15.md
+++ b/claude/skills/cross-llm-review/samples/waypoint-pr-15.md
@@ -1,0 +1,65 @@
+## Summary
+
+This PR overhauls the "status query" and context-sharing mechanisms between the owner and butler in the system. It replaces the old triage view with a richer, thread-based narrative that merges active and archived dispatches, introduces stricter summary writing guidelines, and clarifies the display and archival rules for dispatches, especially around weekends and context retention.
+
+## Concerns
+
+### CLAUDE.md
+> ```diff
+> +summary 是 recent context 段的载体 — owner 24 小时甚至 3 天后看到这条，必须能立刻明白做了什么、为什么、结果如何。它不是机器元数据，是给人读的 context。
+> +写作要求：
+> +1. 自包含 — 不依赖 dispatch_id、不依赖 owner 记得当时上下文。owner 隔几天回来看到这条，必须能立刻读懂。
+> +...
+> +状态推进时（dispatched → delivered/green/blocked），summary 必须随之改写以反映新结果，不能停留在 dispatch 时的初稿。
+> ```
+
+**Risk:**  
+The new summary requirements are much stricter and require manual discipline or code enforcement. If not programmatically enforced, summaries may still be left in an outdated or incomplete state, especially during rapid status transitions. This could undermine the intended context clarity.
+
+---
+
+> ```diff
+> +active + archive 合并读取，不受 24h 归档规则影响 — 归档只是物理位置变化，读取时合并即可。
+> ```
+
+**Risk:**  
+Merging active and archived dispatches for context display is a sound idea, but if the archive grows large, this could introduce performance issues or unbounded memory usage, especially if not paginated or limited to "recent N" as described. The spec says "最近 3-5 条 summary" but does not clarify if this is enforced in code.
+
+---
+
+> ```diff
+> +相关 repo 的 open issues（按 dispatch table 涉及到的 repo 去查 `gh` / `glab`）
+> ```
+
+**Risk:**  
+Querying external issue trackers (GitHub/GitLab) for every status query could introduce latency, rate-limiting, or failure modes if the network is down or credentials are missing. There is no mention of error handling or fallback behavior.
+
+---
+
+### dispatch-table.md
+
+> ```diff
+> +2. butler 自完成 general 任务时：执行成功且无需 owner 决策的，直接推 status → green，last_update_source=auto_complete。这条任务进入 archive 流程（24h 后归档），不在 active items 段显示，但仍可能出现在 recent context 段（最近 N 条范围内）。
+> ```
+
+**Risk:**  
+The distinction between "active items" and "recent context" is now more nuanced. If the code that generates these views is not updated in lockstep, there is a risk of confusion or inconsistency in what the owner sees, especially for green/archived items.
+
+---
+
+## Questions for the author
+
+1. Is there code in place to enforce the new summary writing requirements, or is this purely a documentation/process change?
+2. How is the "recent N" (3-5) limit enforced when merging active and archived dispatches for the context view? Is there a risk of unbounded output?
+3. What is the fallback behavior if external issue tracker queries fail or are slow? Is the status query robust to network/API errors?
+4. Are there automated tests covering the new context loading and thread narrative logic, especially for edge cases (e.g., empty archive, only archived items, large archives)?
+
+## What looks good
+
+- The separation of "recent context" and "active items" is well-motivated and addresses real user workflow pain points.
+- The summary writing guidelines are clear, actionable, and likely to improve long-term context retention.
+- The documentation is thorough, with concrete examples and anti-patterns, which will help maintainers and users understand the new expectations.
+
+---
+_cross-llm-review · model: see invocation · premiumRequests: 0 · api: 101315ms · session: 103079ms_
+[cross-llm-review] kept isolation dir: /tmp/cross-llm-review/1775650600-26870


### PR DESCRIPTION
## Summary

- New skill `claude/skills/cross-llm-review/` wrapping GitHub Copilot CLI (gpt-4.1, free tier) for independent second-opinion PR reviews
- Hard isolation: `--no-custom-instructions` + `--disable-builtin-mcps` + fresh `/tmp` cwd — all three motivated by prior pollution incidents documented in #17
- Deploys via the existing `setup.sh` symlink of `claude/skills/` — no installer changes; once merged, `./setup.sh` on each of the 5 machines picks it up

## Design notes

- Bundle (PR metadata + diff) is **inlined into the prompt**, not referenced as a file. Copilot in `-p` mode does not proactively use read tools — first dogfood attempt produced a hallucinated `sanitize_input` review of a fictional JS PR. Inlining is the only way to guarantee the model sees the real diff.
- Default model `gpt-4.1` (`premiumRequests=0`); `--model gpt-5.x` available for high-stakes escalation
- Output sections: Summary / Concerns / Questions / What looks good

## Dogfood evidence

`samples/waypoint-pr-15.md` — review of `JackonYang/waypoint#15` (ledger as shared context, 165 additions across CLAUDE.md + dispatch-table.md). The review:

- Quotes real diff lines from both files
- Identifies enforcement gap on summary writing requirements (doc-only vs. code-enforced)
- Flags unbounded archive read risk in the active+archive merge
- Notes network-dependency fragility in cross-repo issue queries
- Asks 4 concrete questions, not boilerplate

`premiumRequests=0`, 101s API duration, no premium quota burn.

## Test plan

- [x] copilot CLI isolated probe (PROBE_OK in fresh /tmp cwd)
- [x] dogfood on waypoint#15 — grounded, real review
- [ ] manual verification on a second real PR after merge to confirm reproducibility across repos
- [ ] verify deployment on at least one other machine after merge

## Acceptance criteria from #17

- [x] skill files in `claude/skills/cross-llm-review/`
- [x] verified callable on local Mac with sensible output
- [x] documented isolation template, model selection, error modes
- [ ] second real-PR demo case (will add after merge — first one is the waypoint#15 sample)

Stops at ready-for-review per global automation boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)