### PR TITLE
feat(#33): tmux-cc-ops skill — spawn/poll/classify CC executor windows

### DIFF
--- a/claude/skills/tmux-cc-ops/SKILL.md
+++ b/claude/skills/tmux-cc-ops/SKILL.md
@@ -13,6 +13,21 @@ tmux + Claude Code 操控 SOP。给调度器（butler 等）做远程/本地 CC 
 - 已有 tmux window 需要 poll 状态
 - `consumer.kind=tmux_window` 的 dispatch 需要落地
 
+## 任意 N pane grid 布局
+
+通用方法：split-window N-1 次 → `select-layout tiled` 自动排列。
+
+```bash
+# 2×3 = 6 pane: 1 原始 + 5 次 split → tiled
+for i in $(seq 1 5); do tmux split-window -t ${SESSION}:${WINDOW}; done
+tmux select-layout -t ${SESSION}:${WINDOW} tiled
+
+# 2×4 = 8 pane: 1 原始 + 7 次 split → tiled
+# 3×3 = 9 pane: 1 原始 + 8 次 split → tiled
+```
+
+远程：每条 tmux 命令前加 `ssh "$MACHINE"`。tiled 根据终端尺寸自动选行列比，宽屏接近 RxC，窄屏可能变形，可接受。
+
 ## Hard Rules
 
 1. tmux server 必须跑在 executor 机器上，不是 butler 本地。远程 executor = `ssh X → tmux new-window → claude`，禁止 `本地 tmux → ssh X → claude`。原因：后者 SSH 断则 CC 收 SIGHUP 退出，executor 寿命跟 butler session 绑死。
@@ -69,17 +84,6 @@ classify 实现要点：
 - catch-all 是 `idle` 不是 `dead`；`dead` 必须严格按积极证据返回
 - 函数必须 pure，无 side effect
 
-## 多 executor 布局：2×3 grid
-
-```bash
-SESSION=jack; WINDOW="executor-pool"; MACHINE=116
-ssh "$MACHINE" "tmux new-window -t ${SESSION}: -n ${WINDOW}"
-for i in $(seq 1 5); do ssh "$MACHINE" "tmux split-window -t ${SESSION}:${WINDOW}"; done
-ssh "$MACHINE" "tmux select-layout -t ${SESSION}:${WINDOW} tiled"
-```
-
-pane 数不是 6 的整数倍时 tiled 做不均匀切分，可接受。
-
 ## Worked example: spawn → brief → poll → harvest
 
 ```bash
@@ -129,4 +133,4 @@ done
 
 ## Non-goals
 
-- 不提供脚本封装；不管 dispatch ledger / receipt 格式；不做路由决策；不管 brief 语义内容；不替用户做权限决策（hard rule #3）；不覆盖 trust-this-directory sandbox prompt。
+- 不管 dispatch ledger / receipt 格式；不做路由决策；不管 brief 语义内容；不替用户做权限决策（hard rule #3）；不覆盖 trust-this-directory sandbox prompt。

--- a/claude/skills/tmux-cc-ops/SKILL.md
+++ b/claude/skills/tmux-cc-ops/SKILL.md
@@ -5,401 +5,128 @@ description: Primitives for spawning, prompting, capturing, and state-classifyin
 
 # tmux-cc-ops
 
-tmux + Claude Code 操控的 SOP。给调度器（butler 等）做远程/本地 CC executor 池用，把"开窗、送 brief、捞输出、判状态"这套反复手写的活儿固化成可抄的 helper pattern。本身不提供脚本封装，调用方按 SOP 现写 bash/Python 即可。
+tmux + Claude Code 操控 SOP。给调度器（butler 等）做远程/本地 CC executor 池用。本身不提供脚本封装，调用方按 SOP 现写 bash/Python。
 
 ## Triggers
 
-- 调度器/butler 要 spawn 一个新的 CC executor 跑某个 brief（local 或远程机器）
-- 已存在的 tmux window 需要 poll 状态判断"该不该收尾 / 该不该追问 / 该不该重起"
-- 用户说 "去 116 开个 window 跑 claude 干 X" / "看一下 jack:w3 那个 CC 现在在干嘛" / "把这个 brief 喂给 jackon.me 那个 idle 的 executor"
-- consumer.kind=tmux_window 的 dispatch 需要落地
+- 调度器要 spawn 新 CC executor（local 或远程）
+- 已有 tmux window 需要 poll 状态
+- `consumer.kind=tmux_window` 的 dispatch 需要落地
 
 ## Hard Rules
 
-1. tmux server 必须跑在 executor 机器上，不是 butler 本地。远程 executor = `ssh X → tmux new-window → claude`，禁止 `本地 tmux → ssh X → claude`。原因：后者 SSH 一断，本地 tmux 拉的 pty 跟着死，远端 CC 收 SIGHUP 退出。这条破了，executor 寿命跟 butler session 绑死，整个调度模型崩盘。
-2. spawn CC 时必须切到隔离 cwd，并显式 `--append-system-prompt` 注入"本会话是 executor，照 brief 干活，不要受 cwd CLAUDE.md 里 protocol 词汇拐走"。否则远端 CLAUDE.md（waypoint / jack-vault 等）会立刻把新会话拽进特定 role，brief 失效。
-3. send-keys 提交 prompt 必须是两步：先 paste 文本（literal mode），再单独发一次 `Enter`。一步走 `send-keys "text" Enter` 在多行 brief 上会被解释成 `text\n` 而不是"提交输入框"，CC 会收到一个不完整 prompt。
-4. 状态判定只能基于 sanitized capture-pane 输出（去 ANSI、去 status-line 噪音、保留最后 N 行），不准基于 exit code、tmux pane status、或脑补的时序。判定函数错杀 = 调度系统幻觉。
-5. 永远不替用户决策权限弹窗。识别到 `awaiting_permission` → 上报，不准盲发数字键。绝对禁止向多个 window 盲发 y/Enter — 必须先 capture-pane 确认是权限弹窗（含 Yes/No + esc to cancel）才放行。教训：jack-vault `sop-1-control-n.md` 记录的 2026-03-21 home-reno 事故 — 盲发 y 导致 3 个 window 的决策被自动选 A。
-6. 同一 (machine, session, window) 不允许并发两个 brief。送 brief 之前必须先 classify，确认是 `idle` 或 `done_unread` 才能送，否则会跟前一个任务的 input 撞车。
-7. 远程操作走 `ssh X 'tmux ...'`，每条命令是独立 ssh exec，不维持长连接。短连接 ssh 控制层是稳定的；长连接交互 shell 是不稳定的（参见规则 1）。
-8. `dead` 必须有积极证据，单纯 not-has-tui 不构成 dead 判据。积极证据 = last non-empty line 命中 shell prompt 正则 + capture 非空 + 不是刚从 `busy` / `starting` 跳出来（这些状态有几帧 TUI 缺失是正常的）。证据不足时 catch-all 落 `idle`，让调度方靠多次 poll 的 stability 计数把"持续 idle 但其实是 trust prompt 或 dead pane"的边界 case 收敛掉。误报 dead 会触发"重起 executor"路径，撞上正在启动的 CC、trust-this-directory prompt（已知坑 #7）、或 capture race，直接破坏 owner 介入窗口。
-9. `missing` 是 `capture` primitive 的结构化返回字段，不是 `classify` 的返回值。window/session 不存在 → `capture(...)` 返回 `exists=False`，调用方据此决定是否要 spawn。`classify` 只在 `exists=True && capture_ok=True` 时被调用，只负责"已经在那里、能截到的 pane"的视觉判定。混淆这两个责任会让 classify 用空字符串或 stderr 当输入猜状态，必然误判。
+1. tmux server 必须跑在 executor 机器上，不是 butler 本地。远程 executor = `ssh X → tmux new-window → claude`，禁止 `本地 tmux → ssh X → claude`。原因：后者 SSH 断则 CC 收 SIGHUP 退出，executor 寿命跟 butler session 绑死。
+2. 状态判定只能基于 sanitized capture-pane 输出（去 ANSI、去 status-line 噪音、保留最后 N 行），不准基于 exit code 或脑补时序。
+3. 永远不替用户决策权限弹窗。识别到 `awaiting_permission` → 上报，禁止盲发数字键。必须先 capture-pane 确认含 Yes/No + `esc to cancel` 才放行。
+4. 同一 `(machine, session, window)` 不允许并发两个 brief。送 brief 前先 classify 确认是 `idle` 或 `done_unread`。
+5. 远程操作走 `ssh X 'tmux ...'`，每条命令独立 ssh exec，不维持长连接。
+6. `dead` 必须有积极证据：last non-empty line 命中 shell prompt 正则 + capture 非空 + `prev_state not in (busy, starting)`。证据不足落 `idle`。
 
-## pane_title 状态判定
+## pane_title 快速判定
 
-CC 通过 OSC 转义序列设置终端标题，tmux 自动捕获为 `pane_title`。用它做首轮 busy/idle 判定比纯 capture-pane regex 更可靠 — background agent 运行时 capture-pane 可能显示 `❯` 误判为 idle，但 pane_title 提供了更可靠的信号。
+`tmux display-message -p -t {session}:{window} "#{pane_title}"`
 
-注意：CC 异常退出后 pane_title 可能保留旧值，braille 首字符不会自动清除。pane_title 不能单独依赖 — 必须配合 capture-pane classify 做二次确认，尤其是在 CC 可能已 crash 的场景下。
+| pane_title 首字符 | 判定 |
+|---|---|
+| braille (U+2800–U+28FF) | busy |
+| ✳ (U+2733) | idle |
+| 其他 / 空 | 降级到 capture + classify |
 
-```bash
-tmux display-message -p -t {session}:{window} "#{pane_title}"
-```
+注意：CC 异常退出后 pane_title 可能保留旧值，不能单独依赖，需配合 capture-pane 二次确认。
 
-判定规则（首轮快速判断）：
+## Contract：5 个原子操作
 
-- 首字符是 braille (U+2800–U+28FF) → busy（CC 在跑，旋转动画）
-- 首字符是 ✳ (U+2733) → idle
-- 其他 / 空 → 不确定，降级到 capture-pane + classify 做二次确认
+target 三元组：`(machine, session, window)`，machine = `"local"` 或 ssh host。
 
-推荐用法：先查 `pane_title` 做轻量预判；当 pane_title 不确定或需要更细粒度状态（done_unread、awaiting_permission 等）时，再走完整 capture + classify 流程。两者互补，不是替代关系。
+| op | 输入 | 输出 |
+|---|---|---|
+| spawn_window | target, cwd | target（已起 claude） |
+| send_brief | target, brief_text | — |
+| capture | target, lines=200 | `{exists, capture_ok, text, stderr}`（text 已 sanitize） |
+| classify_state | sanitized text, prev_state | state enum（仅在 `exists && capture_ok` 时调用） |
+| kill_window | target | — |
 
-## Contract
+调度方自己持久化 `(target → last_state, last_capture_hash, last_state_at)`。
 
-调用方需要的 5 个原子操作（每个都是几行 bash，不要封 wrapper）。
+## State enum
 
-target 三元组贯穿所有操作：
+`capture()` 负责 "pane 在不在"，返回 `{exists, capture_ok, text, stderr}`。`exists=False` = `missing`，不进 classify。`classify()` 只在 `exists=True && capture_ok=True` 时调用。
 
-```
-target = (machine, session, window)
-  machine: "local" | "<ssh-host>"   # 116 / 105 / 101 / jackon.me / ...
-  session: tmux session name        # 通常 "jack"
-  window:  tmux window name         # 任务 topic，如 "33-tmux-cc-ops"
-```
+| state | 判据（sanitized tail ~80 行，顺序 match） |
+|---|---|
+| starting | 出现 `Welcome to Claude Code` / `Loading…` / `Initializing`，且无 TUI box 字符 |
+| busy | last5 含 `esc to interrupt`，或 spinner 词（Cogitating/Thinking/Working 等）+ `…` |
+| awaiting_permission | tail 同时含 `Do you want to`/`Allow` + 编号选项 `1.` + `esc to cancel` |
+| error | tail[-10:] 含 `panic:` / `Traceback` / `^API Error`，且 has_tui=True |
+| done_unread | has_tui=True + idle 视觉判据 + `prev_state == busy` |
+| idle | TUI 输入框特征（`│ > ` / `╰─` / `? for shortcuts`），或证据不足的 catch-all |
+| dead | 积极证据全满足：shell prompt 在末行 + capture 非空 + prev_state 不在 busy/starting |
 
-操作集：
+调度方语义层：`missing`（`exists=False`）、`capture_failed`（`exists=True, capture_ok=False`）不进 classify。
 
-| op                 | 输入                                  | 输出                                                              |
-|--------------------|---------------------------------------|-------------------------------------------------------------------|
-| spawn_window       | target, cwd, brief (optional)         | target (已起 claude)                                              |
-| send_brief         | target, brief_text                    | -                                                                 |
-| capture            | target, lines=200                     | dict `{exists, capture_ok, text, stderr}`（text 已 sanitize）     |
-| classify_state     | sanitized text, prev_state (optional) | enum (见 State 段；只在 `exists && capture_ok` 时调用)            |
-| kill_window        | target                                | -                                                                 |
+classify 实现要点：
+- 输入必须是 sanitized text，接受 `prev_state` 参数
+- catch-all 是 `idle` 不是 `dead`；`dead` 必须严格按积极证据返回
+- 函数必须 pure，无 side effect
 
-调度方自己持久化 `(target → last_state, last_capture_hash, last_state_at)`，不在本 skill 范围。
-
-## State enum (核心)
-
-责任分两层：
-
-- `capture(target)` 负责 "pane 在不在 / 能不能截"，返回 `{exists, capture_ok, text, stderr}`。`exists=False` 即调度方语义里的 `missing`，不需要 classify 参与。
-- `classify(sanitized_text, prev_state)` 只在 `exists=True && capture_ok=True` 时被调用，对一个"已经在那里、能截到"的 pane 做视觉判定，返回下面 7 个值之一。判据按从上到下顺序逐条 match，第一个 match 即返回。
-
-```
-starting           CC 正在启动 (splash 还在)
-busy               CC 正在跑 tool / 思考
-awaiting_permission CC 卡在权限弹窗等用户选 1/2/3
-error              CC 在 TUI 内打了 error / panic / traceback
-done_unread        前一轮 busy 跑完，prompt 回到 idle 但还没人收
-idle               空 prompt 等输入（且不是 done_unread）；也是所有"证据不足"情况的 catch-all
-dead               window 存在但里面不是 CC — 必须有积极证据（见下）
-```
-
-调度方语义层另有两个状态，由 `capture` 直接产出，不进 `classify`：
-
-```
-missing            capture(...).exists == False (window/session 不存在)
-capture_failed     capture(...).exists == True && capture_ok == False
-                   (tmux 报错但 window 还在，例如 socket race / pane 太窄 / 权限问题)
-```
-
-判据（grep 的是 sanitized capture 的最后 ~80 行）。`missing` / `capture_failed` 不在 classify 内 — 见上面责任划分。判据顺序与 classifier 实现一致：
-
-1. starting
-   - 判据: 出现 `Welcome to Claude Code` / `Loading…` / `Initializing` / 单独的 `claude` 命令回显但还没 TUI box 字符
-   - 反例: TUI box 已经画出来 + 有 `>` 输入框 = 不再是 starting。
-
-2. busy
-   - 判据: 末尾任意一行包含 `esc to interrupt`，或匹配 spinner 短语正则 `\b(Cogitating|Pondering|Synthesizing|Thinking|Working|Reasoning|Computing|Brewing|Distilling|Hatching|Conjuring|Musing|Marinating|Percolating|Ruminating|Simmering|Stewing|Vibing|Wandering|Whirring)…?\b`，或形如 `(\d+s · [↑↓] [\d.]+k? tokens · esc to interrupt)` 的 footer
-   - 反例: 历史输出里出现过 "esc to interrupt" 但当前最末几行没有 → 已经不 busy；要锚定在 last ~5 lines，不是整张 capture。
-
-3. awaiting_permission
-   - 判据: 末尾 N 行同时出现 `Do you want to` (或 `Allow` / `Approve`) + 形如 `^\s*[│\s]*1\.\s` 的编号选项 + `esc to cancel`（不是 interrupt）
-   - 反例: 普通 numbered list 不是权限弹窗。必须三个 marker 同时 match。
-
-4. error
-   - 判据: tail 出现 `panic:` / `Traceback (most recent call last)` / `^API Error`，且 has_tui 为真（被 TUI box 包住），且没有 busy spinner、没有权限弹窗
-   - 反例: CC 在工具输出里 echo 了 "Error:" 字样不算。判定保守一点，宁愿落到 idle 也不要假报 error。
-   - 注意: 只在 `has_tui == True` 时考虑，否则归到 dead/idle 判定路径。
-
-5. done_unread
-   - 判据: has_tui 为真 + 当前满足 idle 的视觉判据，但 `prev_state == busy`（即上一轮 poll 是 busy）。无 prev_state 时不准返回 done_unread，保守落到 idle。
-   - 替代判据: capture 最后非空行是 Claude 的响应内容（不是 `>` 输入框 echo），且输入框是空的 — 这个判据 false positive 比较高，主用 prev_state 转移。
-
-6. idle
-   - 判据: 末尾出现 CC TUI 的输入框特征：`│ > ` / `╰─` 边框 + `? for shortcuts` 一类 footer hint，且没有 spinner、没有权限弹窗、没有 starting splash
-   - catch-all 角色: 任何"证据不足"的情况（trust-prompt、capture race、空帧、非 TUI 但又不满足 dead 的积极证据）都落 idle。`idle` 是 classify 的安全 default，调度方应当靠多次 poll 的 stability 计数把"持续 idle 但其实是 trust prompt 或 dead pane"的边界 case 收敛掉。
-
-7. dead — 严格要求积极证据，全部满足才返回（hard rule #8）：
-   - last non-empty line 命中 shell prompt 正则（`$` / `❯` / `%` / `#` 在行尾），或 `command not found` / `Process completed` 字样出现在 tail
-   - sanitized text 非空且体量 > 一个最小阈值（避免一帧空白 capture 触发）
-   - tail 内任何一行都没有 CC TUI 特征（`│ >` / `╰─` / `? for shortcuts`）
-   - `prev_state not in (busy, starting)` — 这两个状态有几帧 TUI 缺失是正常的，不算 dead
-   - 反例: trust-this-directory prompt（已知坑 #7）— 非 TUI 提问框，没有 shell prompt 字符，会落 idle 而不是 dead；调度方需要靠单独的 trust-prompt 探测或 stability 计数兜底
-   - 反例: capture race / 短暂空屏 / CC 启动瞬态 — 都不满足"shell prompt at end + 非空 + prev_state 干净"，会落 idle
-
-判定函数的实现骨架（调用方现场抄）：
-
-```python
-import re
-
-SPINNER_RE = re.compile(
-    r"\b(Cogitating|Pondering|Synthesizing|Thinking|Working|Reasoning|"
-    r"Computing|Brewing|Distilling|Hatching|Conjuring|Musing|Marinating|"
-    r"Percolating|Ruminating|Simmering|Stewing|Vibing|Wandering|Whirring)"
-)
-ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]")
-# anchored at end of a *single line*: optional cwd + one of $ ❯ % # at the very end
-SHELL_PROMPT_RE = re.compile(r"[\$❯%#]\s*$")
-DEAD_MIN_BYTES = 40   # below this, treat capture as a transient empty frame
-
-def sanitize(raw: str) -> str:
-    s = ANSI_RE.sub("", raw)
-    # collapse status-line repeats and trailing whitespace
-    lines = [ln.rstrip() for ln in s.splitlines()]
-    out, prev = [], None
-    for ln in lines:
-        if ln == prev:
-            continue
-        out.append(ln); prev = ln
-    return "\n".join(out)
-
-def capture(target, lines: int = 200) -> dict:
-    """tmux capture-pane wrapper.
-
-    Returns {exists, capture_ok, text, stderr}:
-      exists=False        -> window/session not found ("missing" at scheduler layer)
-      exists=True, capture_ok=False -> tmux errored on a present pane (race / perms)
-      exists=True, capture_ok=True  -> text is sanitized, ready to feed classify()
-
-    Caller adapts run() for local vs ssh; key point is that classify() never
-    has to guess between "no pane" and "blank pane".
-    """
-    proc = run([
-        "tmux", "capture-pane",
-        "-t", f"{target.session}:{target.window}",
-        "-p", "-S", f"-{lines}",
-    ])
-    if proc.returncode == 0:
-        return {"exists": True, "capture_ok": True,
-                "text": sanitize(proc.stdout), "stderr": ""}
-    err = proc.stderr or ""
-    if ("can't find window" in err or "no session" in err
-            or "no server running" in err):
-        return {"exists": False, "capture_ok": False, "text": "", "stderr": err}
-    return {"exists": True, "capture_ok": False, "text": "", "stderr": err}
-
-def classify(sanitized_text: str, prev_state: str | None = None) -> str:
-    """Visual classification of a present, captured pane.
-
-    Precondition (caller's responsibility): the corresponding capture() returned
-    exists=True AND capture_ok=True. Never call classify() with "" / None as a
-    way to ask "is the window there?" — that's capture()'s job.
-
-    Returns one of:
-        starting | busy | awaiting_permission | error | done_unread | idle | dead
-    Never returns "missing".
-
-    Catch-all is idle, not dead. dead requires positive evidence (hard rule #8).
-    When in doubt, return idle and let the scheduler's stability counter decide.
-    """
-    text = sanitized_text or ""
-    lines = text.splitlines()
-    tail = "\n".join(lines[-80:])
-    last5 = "\n".join(lines[-5:])
-    last_nonempty = next((ln for ln in reversed(lines) if ln.strip()), "")
-
-    if re.search(r"Welcome to Claude Code|Loading…|Initializing", tail):
-        if "│ >" not in tail and "╰─" not in tail:
-            return "starting"
-
-    if "esc to interrupt" in last5 or SPINNER_RE.search(last5):
-        return "busy"
-
-    if (("Do you want to" in tail or "Allow" in tail)
-            and re.search(r"^\s*[│\s]*1\.\s", tail, re.MULTILINE)
-            and "esc to cancel" in tail):
-        return "awaiting_permission"
-
-    has_tui = ("│ >" in tail) or ("? for shortcuts" in tail) or ("╰─" in tail)
-
-    if has_tui:
-        # has_tui is a coarse guard — error keywords anywhere in the 80-line tail
-        # can false-positive when a tool prints "API Error" while TUI is still up.
-        # This check is intentionally conservative (prefer idle over false error).
-        # Callers must NOT use "error" state to trigger destructive operations.
-        if re.search(r"panic:|Traceback \(most recent call last\)|^API Error",
-                     tail[-10:], re.MULTILINE):
-            return "error"
-        if prev_state == "busy":
-            return "done_unread"
-        return "idle"
-
-    # No TUI in tail. dead requires POSITIVE evidence (hard rule #8):
-    #   1) shell-prompt char at end of last non-empty line, OR
-    #      explicit "command not found" / "Process completed" in tail
-    #   2) capture is non-trivial (guards against transient blank frames)
-    #   3) we are not coming out of busy/starting (those legitimately drop TUI
-    #      for a frame or two — letting that look "dead" is the original bug)
-    dead_signal = (
-        SHELL_PROMPT_RE.search(last_nonempty)
-        or "command not found" in tail
-        or "Process completed" in tail
-    )
-    if (dead_signal
-            and len(text.strip()) >= DEAD_MIN_BYTES
-            and prev_state not in ("busy", "starting")):
-        return "dead"
-
-    # Ambiguous: trust-this-directory prompt, capture race, transient blank,
-    # post-busy frame. Stay idle and let the scheduler's stability counter
-    # decide whether the pane is really stuck.
-    # NEVER catch-all to dead — dead must be earned with positive evidence.
-    return "idle"
-```
-
-判定函数的硬约束：
-
-- 输入是 sanitized text（已经走过 `sanitize`），不是 raw capture。raw 里的 ANSI 会让 regex 全 miss。
-- 必须接受 `prev_state`，否则 `done_unread` / `dead` 的"prev_state 干净"判据全部失效，调度方既分不清"该收 receipt 了"和"对面在 idle 等输入"，也会在 busy → idle 的过渡帧上误报 dead。
-- 任何不确定的情况落到 `idle` 而不是 `error` 或 `dead`。两者都会触发调度方的"重起" / "上报"路径，false positive 代价高，尤其是 dead → 重启会撞上 trust-prompt / 启动中的 CC。
-- `dead` 必须严格按上面的三条积极证据返回 — 不要为了"看起来像 shell" 就放行（呼应 hard rule #8）。
-- `missing` 不在 classify 输出集 — 调用方先调 `capture()`，根据 `exists` 字段判 missing；classify 的输入永远来自 `capture_ok=True` 的分支。
-- 不要在判定函数里做 side effect（不发 send-keys、不写日志），它必须 pure，方便单元测试用 fixture 喂。
-
-## 多 executor 布局：2 行 3 列 grid
-
-需要同时跑多个 executor 并肉眼监控时，tiled 布局最省事：
+## 多 executor 布局：2×3 grid
 
 ```bash
-SESSION=jack
-WINDOW="executor-pool"
-
-# 先确保 window 存在
+SESSION=jack; WINDOW="executor-pool"; MACHINE=116
 ssh "$MACHINE" "tmux new-window -t ${SESSION}: -n ${WINDOW}"
-
-# 再 split 5 次 = 共 6 panes
-ssh "$MACHINE" "tmux split-window -t ${SESSION}:${WINDOW}"
-ssh "$MACHINE" "tmux split-window -t ${SESSION}:${WINDOW}"
-ssh "$MACHINE" "tmux split-window -t ${SESSION}:${WINDOW}"
-ssh "$MACHINE" "tmux split-window -t ${SESSION}:${WINDOW}"
-ssh "$MACHINE" "tmux split-window -t ${SESSION}:${WINDOW}"
-
-# tiled 自动排成 2x3 grid
+for i in $(seq 1 5); do ssh "$MACHINE" "tmux split-window -t ${SESSION}:${WINDOW}"; done
 ssh "$MACHINE" "tmux select-layout -t ${SESSION}:${WINDOW} tiled"
 ```
 
-注意：pane 数不是 6 的整数倍时，tiled 会做不均匀切分，视觉上最后一列可能只有 1 行。可以接受，调度层不感知 pane 布局。
-
-注意：tiled 的行列分布取决于终端尺寸，在宽屏终端上接近 2x3，窄终端可能变 3x2 或其他。不是硬保证。
+pane 数不是 6 的整数倍时 tiled 做不均匀切分，可接受。
 
 ## Worked example: spawn → brief → poll → harvest
 
-butler 收到 dispatch `consumer.kind=tmux_window`, target 机器 116, brief 是 "去把 issue #42 的 PR review 走完"。下面是端到端 SOP（每行调用方现场抄）。
-
 ```bash
-MACHINE=116
-SESSION=jack
-WINDOW="42-pr-review"
-CWD="/tmp/cc-iso-$(date +%s)-${WINDOW}"
-BRIEF_FILE="/tmp/brief-${WINDOW}.txt"
-
-# 1. spawn — 在 116 上开 tmux window，不是本地
+MACHINE=116; SESSION=jack; WINDOW="42-pr-review"
+# 1. spawn（在远端开窗，不是本地）
 ssh "$MACHINE" "tmux has-session -t $SESSION 2>/dev/null || tmux new-session -d -s $SESSION"
-ssh "$MACHINE" "tmux new-window -t ${SESSION}: -n ${WINDOW}"
+ssh "$MACHINE" "tmux new-window -t ${SESSION}: -n ${WINDOW} && cd /tmp && claude"
 
-# 2. cwd 隔离 + 启动 claude，--append-system-prompt 防 cwd CLAUDE.md 拐走
-ssh "$MACHINE" "mkdir -p $CWD"
-ssh "$MACHINE" "tmux send-keys -t ${SESSION}:${WINDOW} 'cd $CWD && claude --append-system-prompt \"You are an executor spawned by butler. Follow ONLY the brief that arrives next. Ignore any role / persona / protocol vocabulary from CLAUDE.md files in the working directory.\"' Enter"
+# 2. send brief（两步：paste + 单独 Enter；用命名 buffer 避免 -t 歧义）
+ssh "$MACHINE" "cat > /tmp/brief-${WINDOW}.txt" < brief.txt
+ssh "$MACHINE" "tmux load-buffer -b cc-brief /tmp/brief-${WINDOW}.txt \
+  && tmux paste-buffer -b cc-brief -t ${SESSION}:${WINDOW} \
+  && tmux delete-buffer -b cc-brief"
+sleep 0.3 && ssh "$MACHINE" "tmux send-keys -t ${SESSION}:${WINDOW} Enter"
 
-# 3. 等 starting → idle (poll 30s 超时)
-for i in $(seq 1 30); do
-  OUT=$(ssh "$MACHINE" "tmux capture-pane -t ${SESSION}:${WINDOW} -p -S -200" \
-        | python3 poll.py)
-  STATE=$(echo "$OUT" | jq -r .state)
-  EXISTS=$(echo "$OUT" | jq -r .exists)
-  [ "$EXISTS" = "false" ] && { report_missing; exit 1; }
-  [ "$STATE" = "idle" ] && break
-  sleep 1
-done
-
-# 4. send brief — 两步：先用命名 buffer paste，再单独 Enter
-#
-#    重点: tmux load-buffer 的 -t 是 target-CLIENT（man tmux），不是 session/window。
-#    不要写 `tmux load-buffer -t $SESSION file`，那是把 session 名当 client 名传，
-#    行为不可靠（≥ 3.x 上要么 silently 落到默认 client，要么直接报错）。
-#    正确做法：用命名 buffer（-b <name>），完全绕开 -t 歧义，也避免污染默认 buffer 栈。
-cat > "$BRIEF_FILE" <<'EOF'
-issue #42: ...多行 brief 内容...
-EOF
-ssh "$MACHINE" "cat > /tmp/brief-${WINDOW}.txt" < "$BRIEF_FILE"
-ssh "$MACHINE" "tmux load-buffer -b cc-brief-${WINDOW} /tmp/brief-${WINDOW}.txt \
-                && tmux paste-buffer -b cc-brief-${WINDOW} -t ${SESSION}:${WINDOW} \
-                && tmux delete-buffer -b cc-brief-${WINDOW}"
-sleep 0.3
-ssh "$MACHINE" "tmux send-keys -t ${SESSION}:${WINDOW} Enter"
-
-# 5. poll loop — 每 N 秒 capture + classify，落 prev_state 状态机。
-#    capture() 把 missing / capture_failed 直接出在 JSON 里，classify() 只见
-#    "存在且能截到"的 pane，所以 case 里 missing / capture_failed 走独立分支。
-#    DEAD_STREAK 让调度方对 dead 做 stability 收敛 — 单次 dead 不动作，
-#    避免误报触发重启撞上 trust-prompt / 启动中的 CC（hard rule #8）。
-PREV=busy
-DEAD_STREAK=0
+# 3. poll loop（prev_state 驱动状态机，dead streak 防误报）
+PREV=busy; DEAD_STREAK=0
 while true; do
-  OUT=$(ssh "$MACHINE" "tmux capture-pane -t ${SESSION}:${WINDOW} -p -S -200" \
-        | PREV_STATE=$PREV python3 poll.py)
-  EXISTS=$(echo "$OUT" | jq -r .exists)
-  CAPTURE_OK=$(echo "$OUT" | jq -r .capture_ok)
-  STATE=$(echo "$OUT" | jq -r .state)
-
-  if [ "$EXISTS" = "false" ]; then report_missing; break; fi
-  if [ "$CAPTURE_OK" = "false" ]; then sleep 5; continue; fi   # tmux race, retry
-
+  STATE=$(ssh "$MACHINE" "tmux capture-pane -t ${SESSION}:${WINDOW} -p -S -200" | PREV_STATE=$PREV python3 poll.py | jq -r .state)
   case "$STATE" in
-    busy)                DEAD_STREAK=0 ;;                              # 继续等
-    awaiting_permission) report_to_owner; break ;;                    # 上报，不代选
-    error)               report_error; break ;;
-    dead)
-      DEAD_STREAK=$((DEAD_STREAK + 1))
-      [ "$DEAD_STREAK" -ge 3 ] && { report_dead; break; }             # 3 连 dead 才动手
-      ;;
-    done_unread)         harvest_capture; break ;;                    # 收尾，写 receipt
-    idle)                DEAD_STREAK=0 ;;                             # idle 是 catch-all，重置计数
+    busy)                DEAD_STREAK=0 ;;
+    awaiting_permission) report_to_owner; break ;;
+    done_unread)         harvest_capture; break ;;
+    dead) DEAD_STREAK=$((DEAD_STREAK+1)); [ $DEAD_STREAK -ge 3 ] && { report_dead; break; } ;;
+    idle) DEAD_STREAK=0 ;;
   esac
-  PREV=$STATE
-  sleep 30
+  PREV=$STATE; sleep 30
 done
 ```
-
-不要把上面这段封进 helper 库 — 每次调用方按自己的状态机（butler ledger / cron poller / 其他）现场拼。封装的成本是丢弃灵活性 + 引入版本漂移。SOP 才是产出物。
 
 ## 已知坑
 
-1. tmux load-buffer -t 是 target-CLIENT，不是 session/window — 这是最常犯的错。`tmux load-buffer -t jack file` 是把 "jack" 当 client 名传，不是 session 名。正确用法：省掉 `-t`（默认 buffer），或用命名 buffer：`tmux load-buffer -b cc-brief file && tmux paste-buffer -b cc-brief -t SESSION:WINDOW && tmux delete-buffer -b cc-brief`。命名 buffer 更好，避免污染默认 buffer 栈。
-2. tmux send-keys 提交多行 input — 用 `load-buffer + paste-buffer + 单独 Enter`，不要 `send-keys "$(cat brief.txt)" Enter`。后者把内嵌 \n 当 Enter，CC 输入框会断成多个不完整 prompt。
-3. capture-pane 默认只截可见区域 — 必须 `-S -200`（或更大）取 history。CC TUI 滚屏快，不取 history 容易 miss spinner 行。
-4. ANSI 不剥不要 grep — CC TUI 大量 SGR 序列把 "esc to interrupt" 切成片段，正则全 miss。先 sanitize 再 classify。
-5. spinner 词表会随 CC 版本扩 — 上面 SPINNER_RE 是 2026-03 的快照，发现新词加进去，不要假定枚举完整。busy 的兜底判据是 `esc to interrupt` 这串字符，比 spinner 词更稳。
-6. SSH ControlMaster 跟 tmux 不冲突，但跟"tmux 跑在本地套 ssh"那种错用法叠加会让症状更迷惑（断连后 mux 还假装活着）。一律按 hard rule #1 走。
-7. status-line / vim-airline 之类装饰会让同一信息每秒刷新，sanitize 必须做"连续相同行去重"，否则 last-N-lines 全是 status-line 噪音。
-8. CC 启动如果遇到未授权目录 / sandbox prompt，会卡在一个非 TUI 的"是否信任此目录"提问 — 这种情况判定函数会落 `idle`（catch-all，因为不满足 dead 的积极证据），调度方需要单独有"trust prompt" 探测（grep `Do you trust the files` / `trust this directory` 之类），本 skill 的 classify 不覆盖这条边界。
-9. window name 含特殊字符（`/`, `:`, 空格）会让 `tmux ... -t session:window` 解析失败。命名时只用 `[A-Za-z0-9_-]`。CWD 构建也应只用 `[A-Za-z0-9_-./]`，避免通过 send-keys 注入。
-10. `tmux has-session` 在远程返回 "no server running" 是正常的（第一次 spawn），按 idempotent 处理，不要把它当 error。
-11. `--append-system-prompt` vs `--system-prompt` — append 保留 CC 的工具能力，replace 会把工具描述也覆盖掉导致 CC 不会调用 tool。executor 隔离用 append，不要用 replace。
-12. iTerm2 CC 集成模式（`-CC` 标志）会破坏 dashboard 布局 — 开了 `-CC` 后 iTerm2 会接管 tmux 的 pane 渲染，`select-layout tiled` 失效，capture-pane 输出也会带额外元数据。调度脚本不要在 `-CC` 模式下跑。
-13. capture-pane 误判 CC idle 状态 — background agent 运行时 pane 末尾可能显示 `❯` 提示符，但 CC 实际仍在运行。应优先用 `pane_title` 首字符（braille = busy，✳ = idle）做首轮判断，capture-pane 降级为二次确认。见 pane_title 状态判定 section。
-14. 并行 claude -p 上限约 4 — CC issue #24990 记录了超过 4 个并发 `-p` 进程时出现 token 争用导致 hang 的问题。executor pool 上限保守设 4，超出时让新任务排队等 idle slot，不要无限 spawn。
-15. agent hang 无超时 — CC 不提供内建的任务超时机制（CC bug #28482）。调度方必须在外层实现 kill 机制：记录 `started_at`，poll 时判断 `now - started_at > threshold` 则强制 `tmux kill-pane` 后重起。阈值根据任务类型自定，建议 10–30 分钟。
+1. `tmux load-buffer -t` 是 target-CLIENT 不是 session — 用命名 buffer：`-b <name>` + `paste-buffer -b <name> -t SESSION:WINDOW`。
+2. send-keys 多行 brief — 用 `load-buffer + paste-buffer + 单独 Enter`，不要 `send-keys "$(cat brief.txt)" Enter`（嵌入 \n 断行）。
+3. capture-pane 默认只截可见区 — 必须 `-S -200` 取 history，否则 miss spinner 行。
+4. ANSI 不剥不要 grep — 先 sanitize 再 classify；spinner 词被 SGR 切段会全 miss。
+5. spinner 词表随版本扩 — 兜底判据用 `esc to interrupt`，比词表更稳。
+6. status-line 噪音 — sanitize 必须做连续相同行去重，否则 last-N-lines 全是 status-line。
+7. CC 启动遇 trust-this-directory prompt — 非 TUI 提问框，classify 落 `idle`（catch-all）。需在调度方单独 grep `trust this directory` 探测，或 spawn 时传 `--dangerously-skip-permissions`。
+8. 并行 `claude -p` 上限约 4（CC issue #24990）— executor pool 保守设 4，超出排队。
 
-## 快捷片段
+## ctx% 快速读取
 
-### ctx% 快速读取
+`tmux capture-pane -t {session}:{window} -p -S -1 | grep -oP 'ctx:\K\d+(?=%)'`
 
-从 pane 末行抓 CC 当前 context 使用百分比（用于调度方判断"是否快 ctx 满了"）：
-
-```bash
-tmux capture-pane -t {session}:{window} -p -S -1 | grep -oP 'ctx:\K\d+(?=%)'
-```
-
-输出示例：`73`（表示 73% context 已用）。抓不到（CC 未显示 ctx% 行）时输出空，调度方按"未知"处理。
+抓不到时输出空，调度方按"未知"处理。
 
 ## Non-goals
 
-- 不提供 bash/python 脚本封装。SOP 是产出物，调用方自己抄。封装会丢弃针对不同调度场景调整的灵活性。
-- 不管 dispatch ledger / receipt 格式 / 状态机持久化 — 那是 butler 等调用方的职责，本 skill 只暴露 5 个 stateless primitive。
-- 不管"哪台 executor 该接哪个 brief" 的路由决策 — 那是 routing 层，不是 ops 层。
-- 不负责 brief 的语义内容 / 模板 / warmup 句注入 — 那是 dispatcher 的事，本 skill 只管 byte-level 送达。
-- 不替用户做权限决策（hard rule #5）。awaiting_permission 永远是上报，不是自动放行。
-- 不覆盖 trust-this-directory 的 sandbox prompt（已知坑 #8），调用方需要在 spawn 时用 `--allow-all-paths` 或预先 trust。
+- 不提供脚本封装；不管 dispatch ledger / receipt 格式；不做路由决策；不管 brief 语义内容；不替用户做权限决策（hard rule #3）；不覆盖 trust-this-directory sandbox prompt。

--- a/claude/skills/tmux-cc-ops/SKILL.md
+++ b/claude/skills/tmux-cc-ops/SKILL.md
@@ -28,7 +28,9 @@ tmux + Claude Code 操控的 SOP。给调度器（butler 等）做远程/本地 
 
 ## pane_title 状态判定
 
-CC 通过 OSC 转义序列设置终端标题，tmux 自动捕获为 `pane_title`。用它做首轮 busy/idle 判定比纯 capture-pane regex 更可靠 — background agent 运行时 capture-pane 可能显示 `❯` 误判为 idle，但 pane_title 的首字符不会撒谎。
+CC 通过 OSC 转义序列设置终端标题，tmux 自动捕获为 `pane_title`。用它做首轮 busy/idle 判定比纯 capture-pane regex 更可靠 — background agent 运行时 capture-pane 可能显示 `❯` 误判为 idle，但 pane_title 提供了更可靠的信号。
+
+注意：CC 异常退出后 pane_title 可能保留旧值，braille 首字符不会自动清除。pane_title 不能单独依赖 — 必须配合 capture-pane classify 做二次确认，尤其是在 CC 可能已 crash 的场景下。
 
 ```bash
 tmux display-message -p -t {session}:{window} "#{pane_title}"
@@ -276,6 +278,8 @@ ssh "$MACHINE" "tmux select-layout -t ${SESSION}:${WINDOW} tiled"
 
 注意：pane 数不是 6 的整数倍时，tiled 会做不均匀切分，视觉上最后一列可能只有 1 行。可以接受，调度层不感知 pane 布局。
 
+注意：tiled 的行列分布取决于终端尺寸，在宽屏终端上接近 2x3，窄终端可能变 3x2 或其他。不是硬保证。
+
 ## Worked example: spawn → brief → poll → harvest
 
 butler 收到 dispatch `consumer.kind=tmux_window`, target 机器 116, brief 是 "去把 issue #42 的 PR review 走完"。下面是端到端 SOP（每行调用方现场抄）。
@@ -285,7 +289,7 @@ MACHINE=116
 SESSION=jack
 WINDOW="42-pr-review"
 CWD="/tmp/cc-iso-$(date +%s)-${WINDOW}"
-BRIEF_FILE=/tmp/brief-${WINDOW}.txt
+BRIEF_FILE="/tmp/brief-${WINDOW}.txt"
 
 # 1. spawn — 在 116 上开 tmux window，不是本地
 ssh "$MACHINE" "tmux has-session -t $SESSION 2>/dev/null || tmux new-session -d -s $SESSION"
@@ -315,10 +319,10 @@ done
 cat > "$BRIEF_FILE" <<'EOF'
 issue #42: ...多行 brief 内容...
 EOF
-ssh "$MACHINE" "cat > /tmp/brief.txt" < "$BRIEF_FILE"
-ssh "$MACHINE" "tmux load-buffer -b cc-brief /tmp/brief.txt \
-                && tmux paste-buffer -b cc-brief -t ${SESSION}:${WINDOW} \
-                && tmux delete-buffer -b cc-brief"
+ssh "$MACHINE" "cat > /tmp/brief-${WINDOW}.txt" < "$BRIEF_FILE"
+ssh "$MACHINE" "tmux load-buffer -b cc-brief-${WINDOW} /tmp/brief-${WINDOW}.txt \
+                && tmux paste-buffer -b cc-brief-${WINDOW} -t ${SESSION}:${WINDOW} \
+                && tmux delete-buffer -b cc-brief-${WINDOW}"
 sleep 0.3
 ssh "$MACHINE" "tmux send-keys -t ${SESSION}:${WINDOW} Enter"
 
@@ -367,7 +371,7 @@ done
 6. SSH ControlMaster 跟 tmux 不冲突，但跟"tmux 跑在本地套 ssh"那种错用法叠加会让症状更迷惑（断连后 mux 还假装活着）。一律按 hard rule #1 走。
 7. status-line / vim-airline 之类装饰会让同一信息每秒刷新，sanitize 必须做"连续相同行去重"，否则 last-N-lines 全是 status-line 噪音。
 8. CC 启动如果遇到未授权目录 / sandbox prompt，会卡在一个非 TUI 的"是否信任此目录"提问 — 这种情况判定函数会落 `idle`（catch-all，因为不满足 dead 的积极证据），调度方需要单独有"trust prompt" 探测（grep `Do you trust the files` / `trust this directory` 之类），本 skill 的 classify 不覆盖这条边界。
-9. window name 含特殊字符（`/`, `:`, 空格）会让 `tmux ... -t session:window` 解析失败。命名时只用 `[A-Za-z0-9_-]`。
+9. window name 含特殊字符（`/`, `:`, 空格）会让 `tmux ... -t session:window` 解析失败。命名时只用 `[A-Za-z0-9_-]`。CWD 构建也应只用 `[A-Za-z0-9_-./]`，避免通过 send-keys 注入。
 10. `tmux has-session` 在远程返回 "no server running" 是正常的（第一次 spawn），按 idempotent 处理，不要把它当 error。
 11. `--append-system-prompt` vs `--system-prompt` — append 保留 CC 的工具能力，replace 会把工具描述也覆盖掉导致 CC 不会调用 tool。executor 隔离用 append，不要用 replace。
 12. iTerm2 CC 集成模式（`-CC` 标志）会破坏 dashboard 布局 — 开了 `-CC` 后 iTerm2 会接管 tmux 的 pane 渲染，`select-layout tiled` 失效，capture-pane 输出也会带额外元数据。调度脚本不要在 `-CC` 模式下跑。

--- a/claude/skills/tmux-cc-ops/SKILL.md
+++ b/claude/skills/tmux-cc-ops/SKILL.md
@@ -1,0 +1,341 @@
+---
+name: tmux-cc-ops
+description: Primitives for spawning, prompting, capturing, and state-classifying remote/local Claude Code sessions running inside tmux windows. Use when a scheduler/butler needs to operate CC sessions as worker pool — spawn on (machine, session, window), send a brief, poll pane to decide idle / busy / awaiting-permission / done-unread / dead. Not for interactive single-session use.
+---
+
+# tmux-cc-ops
+
+tmux + Claude Code 操控的 SOP。给调度器（butler 等）做远程/本地 CC executor 池用，把"开窗、送 brief、捞输出、判状态"这套反复手写的活儿固化成可抄的 helper pattern。本身不提供脚本封装，调用方按 SOP 现写 bash/Python 即可。
+
+## Triggers
+
+- 调度器/butler 要 spawn 一个新的 CC executor 跑某个 brief（local 或远程机器）
+- 已存在的 tmux window 需要 poll 状态判断"该不该收尾 / 该不该追问 / 该不该重起"
+- 用户说 "去 116 开个 window 跑 claude 干 X" / "看一下 jack:w3 那个 CC 现在在干嘛" / "把这个 brief 喂给 jackon.me 那个 idle 的 executor"
+- consumer.kind=tmux_window 的 dispatch 需要落地
+
+## Hard Rules
+
+1. tmux server 必须跑在 executor 机器上，不是 butler 本地。远程 executor = `ssh X → tmux new-window → claude`，禁止 `本地 tmux → ssh X → claude`。原因：后者 SSH 一断，本地 tmux 拉的 pty 跟着死，远端 CC 收 SIGHUP 退出。这条破了，executor 寿命跟 butler session 绑死，整个调度模型崩盘。
+2. spawn CC 时必须切到隔离 cwd，并显式 `--append-system-prompt` 注入"本会话是 executor，照 brief 干活，不要受 cwd CLAUDE.md 里 protocol 词汇拐走"。否则远端 CLAUDE.md（waypoint / jack-vault 等）会立刻把新会话拽进特定 role，brief 失效。
+3. send-keys 提交 prompt 必须是两步：先 paste 文本（literal mode），再单独发一次 `Enter`。一步走 `send-keys "text" Enter` 在多行 brief 上会被解释成 `text\n` 而不是"提交输入框"，CC 会收到一个不完整 prompt。
+4. 状态判定只能基于 sanitized capture-pane 输出（去 ANSI、去 status-line 噪音、保留最后 N 行），不准基于 exit code、tmux pane status、或脑补的时序。判定函数错杀 = 调度系统幻觉。
+5. 永远不替用户决策权限弹窗。识别到 `awaiting_permission` → 上报，不准盲发数字键。教训：jack-vault `sop-1-control-n.md` 记录的 2026-03-21 home-reno 事故。
+6. 同一 (machine, session, window) 不允许并发两个 brief。送 brief 之前必须先 classify，确认是 `idle` 或 `done_unread` 才能送，否则会跟前一个任务的 input 撞车。
+7. 远程操作走 `ssh X 'tmux ...'`，每条命令是独立 ssh exec，不维持长连接。短连接 ssh 控制层是稳定的；长连接交互 shell 是不稳定的（参见规则 1）。
+8. `dead` 必须有积极证据，单纯 not-has-tui 不构成 dead 判据。积极证据 = last non-empty line 命中 shell prompt 正则 + capture 非空 + 不是刚从 `busy` / `starting` 跳出来（这些状态有几帧 TUI 缺失是正常的）。证据不足时 catch-all 落 `idle`，让调度方靠多次 poll 的 stability 计数把"持续 idle 但其实是 trust prompt 或 dead pane"的边界 case 收敛掉。误报 dead 会触发"重起 executor"路径，撞上正在启动的 CC、trust-this-directory prompt（已知坑 #7）、或 capture race，直接破坏 owner 介入窗口。
+9. `missing` 是 `capture` primitive 的结构化返回字段，不是 `classify` 的返回值。window/session 不存在 → `capture(...)` 返回 `exists=False`，调用方据此决定是否要 spawn。`classify` 只在 `exists=True && capture_ok=True` 时被调用，只负责"已经在那里、能截到的 pane"的视觉判定。混淆这两个责任会让 classify 用空字符串或 stderr 当输入猜状态，必然误判。
+
+## Contract
+
+调用方需要的 5 个原子操作（每个都是几行 bash，不要封 wrapper）。
+
+target 三元组贯穿所有操作：
+
+```
+target = (machine, session, window)
+  machine: "local" | "<ssh-host>"   # 116 / 105 / 101 / jackon.me / ...
+  session: tmux session name        # 通常 "jack"
+  window:  tmux window name         # 任务 topic，如 "33-tmux-cc-ops"
+```
+
+操作集：
+
+| op                 | 输入                                  | 输出                                                              |
+|--------------------|---------------------------------------|-------------------------------------------------------------------|
+| spawn_window       | target, cwd, brief (optional)         | target (已起 claude)                                              |
+| send_brief         | target, brief_text                    | -                                                                 |
+| capture            | target, lines=200                     | dict `{exists, capture_ok, text, stderr}`（text 已 sanitize）     |
+| classify_state     | sanitized text, prev_state (optional) | enum (见 State 段；只在 `exists && capture_ok` 时调用)            |
+| kill_window        | target                                | -                                                                 |
+
+调度方自己持久化 `(target → last_state, last_capture_hash, last_state_at)`，不在本 skill 范围。
+
+## State enum (核心)
+
+责任分两层：
+
+- `capture(target)` 负责 "pane 在不在 / 能不能截"，返回 `{exists, capture_ok, text, stderr}`。`exists=False` 即调度方语义里的 `missing`，不需要 classify 参与。
+- `classify(sanitized_text, prev_state)` 只在 `exists=True && capture_ok=True` 时被调用，对一个"已经在那里、能截到"的 pane 做视觉判定，返回下面 7 个值之一。判据按从上到下顺序逐条 match，第一个 match 即返回。
+
+```
+starting           CC 正在启动 (splash 还在)
+busy               CC 正在跑 tool / 思考
+awaiting_permission CC 卡在权限弹窗等用户选 1/2/3
+error              CC 在 TUI 内打了 error / panic / traceback
+done_unread        前一轮 busy 跑完，prompt 回到 idle 但还没人收
+idle               空 prompt 等输入（且不是 done_unread）；也是所有"证据不足"情况的 catch-all
+dead               window 存在但里面不是 CC — 必须有积极证据（见下）
+```
+
+调度方语义层另有两个状态，由 `capture` 直接产出，不进 `classify`：
+
+```
+missing            capture(...).exists == False (window/session 不存在)
+capture_failed     capture(...).exists == True && capture_ok == False
+                   (tmux 报错但 window 还在，例如 socket race / pane 太窄 / 权限问题)
+```
+
+判据（grep 的是 sanitized capture 的最后 ~80 行）。`missing` / `capture_failed` 不在 classify 内 — 见上面责任划分。判据顺序与 classifier 实现一致：
+
+1. starting
+   - 判据: 出现 `Welcome to Claude Code` / `Loading…` / `Initializing` / 单独的 `claude` 命令回显但还没 TUI box 字符
+   - 反例: TUI box 已经画出来 + 有 `>` 输入框 = 不再是 starting。
+
+2. busy
+   - 判据: 末尾任意一行包含 `esc to interrupt`，或匹配 spinner 短语正则 `\b(Cogitating|Pondering|Synthesizing|Thinking|Working|Reasoning|Computing|Brewing|Distilling|Hatching|Conjuring|Musing|Marinating|Percolating|Ruminating|Simmering|Stewing|Vibing|Wandering|Whirring)…?\b`，或形如 `(\d+s · [↑↓] [\d.]+k? tokens · esc to interrupt)` 的 footer
+   - 反例: 历史输出里出现过 "esc to interrupt" 但当前最末几行没有 → 已经不 busy；要锚定在 last ~5 lines，不是整张 capture。
+
+3. awaiting_permission
+   - 判据: 末尾 N 行同时出现 `Do you want to` (或 `Allow` / `Approve`) + 形如 `^\s*[│\s]*1\.\s` 的编号选项 + `esc to cancel`（不是 interrupt）
+   - 反例: 普通 numbered list 不是权限弹窗。必须三个 marker 同时 match。
+
+4. error
+   - 判据: tail 出现 `panic:` / `Traceback (most recent call last)` / `^API Error`，且 has_tui 为真（被 TUI box 包住），且没有 busy spinner、没有权限弹窗
+   - 反例: CC 在工具输出里 echo 了 "Error:" 字样不算。判定保守一点，宁愿落到 idle 也不要假报 error。
+   - 注意: 只在 `has_tui == True` 时考虑，否则归到 dead/idle 判定路径。
+
+5. done_unread
+   - 判据: has_tui 为真 + 当前满足 idle 的视觉判据，但 `prev_state == busy`（即上一轮 poll 是 busy）。无 prev_state 时不准返回 done_unread，保守落到 idle。
+   - 替代判据: capture 最后非空行是 Claude 的响应内容（不是 `>` 输入框 echo），且输入框是空的 — 这个判据 false positive 比较高，主用 prev_state 转移。
+
+6. idle
+   - 判据: 末尾出现 CC TUI 的输入框特征：`│ > ` / `╰─` 边框 + `? for shortcuts` 一类 footer hint，且没有 spinner、没有权限弹窗、没有 starting splash
+   - catch-all 角色: 任何"证据不足"的情况（trust-prompt、capture race、空帧、非 TUI 但又不满足 dead 的积极证据）都落 idle。`idle` 是 classify 的安全 default，调度方应当靠多次 poll 的 stability 计数把"持续 idle 但其实是 trust prompt 或 dead pane"的边界 case 收敛掉。
+
+7. dead — 严格要求积极证据，全部满足才返回（hard rule #8）：
+   - last non-empty line 命中 shell prompt 正则（`$` / `❯` / `%` / `#` 在行尾），或 `command not found` / `Process completed` 字样出现在 tail
+   - sanitized text 非空且体量 > 一个最小阈值（避免一帧空白 capture 触发）
+   - tail 内任何一行都没有 CC TUI 特征（`│ >` / `╰─` / `? for shortcuts`）
+   - `prev_state not in (busy, starting)` — 这两个状态有几帧 TUI 缺失是正常的，不算 dead
+   - 反例: trust-this-directory prompt（已知坑 #7）— 非 TUI 提问框，没有 shell prompt 字符，会落 idle 而不是 dead；调度方需要靠单独的 trust-prompt 探测或 stability 计数兜底
+   - 反例: capture race / 短暂空屏 / CC 启动瞬态 — 都不满足"shell prompt at end + 非空 + prev_state 干净"，会落 idle
+
+判定函数的实现骨架（调用方现场抄）：
+
+```python
+import re
+
+SPINNER_RE = re.compile(
+    r"\b(Cogitating|Pondering|Synthesizing|Thinking|Working|Reasoning|"
+    r"Computing|Brewing|Distilling|Hatching|Conjuring|Musing|Marinating|"
+    r"Percolating|Ruminating|Simmering|Stewing|Vibing|Wandering|Whirring)"
+)
+ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]")
+# anchored at end of a *single line*: optional cwd + one of $ ❯ % # at the very end
+SHELL_PROMPT_RE = re.compile(r"[\$❯%#]\s*$")
+DEAD_MIN_BYTES = 40   # below this, treat capture as a transient empty frame
+
+def sanitize(raw: str) -> str:
+    s = ANSI_RE.sub("", raw)
+    # collapse status-line repeats and trailing whitespace
+    lines = [ln.rstrip() for ln in s.splitlines()]
+    out, prev = [], None
+    for ln in lines:
+        if ln == prev:
+            continue
+        out.append(ln); prev = ln
+    return "\n".join(out)
+
+def capture(target, lines: int = 200) -> dict:
+    """tmux capture-pane wrapper.
+
+    Returns {exists, capture_ok, text, stderr}:
+      exists=False        -> window/session not found ("missing" at scheduler layer)
+      exists=True, capture_ok=False -> tmux errored on a present pane (race / perms)
+      exists=True, capture_ok=True  -> text is sanitized, ready to feed classify()
+
+    Caller adapts run() for local vs ssh; key point is that classify() never
+    has to guess between "no pane" and "blank pane".
+    """
+    proc = run([
+        "tmux", "capture-pane",
+        "-t", f"{target.session}:{target.window}",
+        "-p", "-S", f"-{lines}",
+    ])
+    if proc.returncode == 0:
+        return {"exists": True, "capture_ok": True,
+                "text": sanitize(proc.stdout), "stderr": ""}
+    err = proc.stderr or ""
+    if ("can't find window" in err or "no session" in err
+            or "no server running" in err):
+        return {"exists": False, "capture_ok": False, "text": "", "stderr": err}
+    return {"exists": True, "capture_ok": False, "text": "", "stderr": err}
+
+def classify(sanitized_text: str, prev_state: str | None = None) -> str:
+    """Visual classification of a present, captured pane.
+
+    Precondition (caller's responsibility): the corresponding capture() returned
+    exists=True AND capture_ok=True. Never call classify() with "" / None as a
+    way to ask "is the window there?" — that's capture()'s job.
+
+    Returns one of:
+        starting | busy | awaiting_permission | error | done_unread | idle | dead
+    Never returns "missing".
+
+    Catch-all is idle, not dead. dead requires positive evidence (hard rule #8).
+    When in doubt, return idle and let the scheduler's stability counter decide.
+    """
+    text = sanitized_text or ""
+    lines = text.splitlines()
+    tail = "\n".join(lines[-80:])
+    last5 = "\n".join(lines[-5:])
+    last_nonempty = next((ln for ln in reversed(lines) if ln.strip()), "")
+
+    if re.search(r"Welcome to Claude Code|Loading…|Initializing", tail):
+        if "│ >" not in tail and "╰─" not in tail:
+            return "starting"
+
+    if "esc to interrupt" in last5 or SPINNER_RE.search(last5):
+        return "busy"
+
+    if (("Do you want to" in tail or "Allow" in tail)
+            and re.search(r"^\s*[│\s]*1\.\s", tail, re.MULTILINE)
+            and "esc to cancel" in tail):
+        return "awaiting_permission"
+
+    has_tui = ("│ >" in tail) or ("? for shortcuts" in tail) or ("╰─" in tail)
+
+    if has_tui:
+        if re.search(r"panic:|Traceback \(most recent call last\)|^API Error",
+                     tail, re.MULTILINE):
+            return "error"
+        if prev_state == "busy":
+            return "done_unread"
+        return "idle"
+
+    # No TUI in tail. dead requires POSITIVE evidence (hard rule #8):
+    #   1) shell-prompt char at end of last non-empty line, OR
+    #      explicit "command not found" / "Process completed" in tail
+    #   2) capture is non-trivial (guards against transient blank frames)
+    #   3) we are not coming out of busy/starting (those legitimately drop TUI
+    #      for a frame or two — letting that look "dead" is the original bug)
+    dead_signal = (
+        SHELL_PROMPT_RE.search(last_nonempty)
+        or "command not found" in tail
+        or "Process completed" in tail
+    )
+    if (dead_signal
+            and len(text.strip()) >= DEAD_MIN_BYTES
+            and prev_state not in ("busy", "starting")):
+        return "dead"
+
+    # Ambiguous: trust-this-directory prompt, capture race, transient blank,
+    # post-busy frame. Stay idle and let the scheduler's stability counter
+    # decide whether the pane is really stuck.
+    # NEVER catch-all to dead — dead must be earned with positive evidence.
+    return "idle"
+```
+
+判定函数的硬约束：
+
+- 输入是 sanitized text（已经走过 `sanitize`），不是 raw capture。raw 里的 ANSI 会让 regex 全 miss。
+- 必须接受 `prev_state`，否则 `done_unread` / `dead` 的"prev_state 干净"判据全部失效，调度方既分不清"该收 receipt 了"和"对面在 idle 等输入"，也会在 busy → idle 的过渡帧上误报 dead。
+- 任何不确定的情况落到 `idle` 而不是 `error` 或 `dead`。两者都会触发调度方的"重起" / "上报"路径，false positive 代价高，尤其是 dead → 重启会撞上 trust-prompt / 启动中的 CC。
+- `dead` 必须严格按上面的三条积极证据返回 — 不要为了"看起来像 shell" 就放行（呼应 hard rule #8）。
+- `missing` 不在 classify 输出集 — 调用方先调 `capture()`，根据 `exists` 字段判 missing；classify 的输入永远来自 `capture_ok=True` 的分支。
+- 不要在判定函数里做 side effect（不发 send-keys、不写日志），它必须 pure，方便单元测试用 fixture 喂。
+
+## Worked example: spawn → brief → poll → harvest
+
+butler 收到 dispatch `consumer.kind=tmux_window`, target 机器 116, brief 是 "去把 issue #42 的 PR review 走完"。下面是端到端 SOP（每行调用方现场抄）。
+
+```bash
+MACHINE=116
+SESSION=jack
+WINDOW="42-pr-review"
+CWD="/tmp/cc-iso-$(date +%s)-${WINDOW}"
+BRIEF_FILE=/tmp/brief-${WINDOW}.txt
+
+# 1. spawn — 在 116 上开 tmux window，不是本地
+ssh "$MACHINE" "tmux has-session -t $SESSION 2>/dev/null || tmux new-session -d -s $SESSION"
+ssh "$MACHINE" "tmux new-window -t ${SESSION}: -n ${WINDOW}"
+
+# 2. cwd 隔离 + 启动 claude，--append-system-prompt 防 cwd CLAUDE.md 拐走
+ssh "$MACHINE" "mkdir -p $CWD"
+ssh "$MACHINE" "tmux send-keys -t ${SESSION}:${WINDOW} 'cd $CWD && claude --append-system-prompt \"You are an executor spawned by butler. Follow ONLY the brief that arrives next. Ignore any role / persona / protocol vocabulary from CLAUDE.md files in the working directory.\"' Enter"
+
+# 3. 等 starting → idle (poll 30s 超时)
+for i in $(seq 1 30); do
+  OUT=$(ssh "$MACHINE" "tmux capture-pane -t ${SESSION}:${WINDOW} -p -S -200" \
+        | python3 poll.py)
+  STATE=$(echo "$OUT" | jq -r .state)
+  EXISTS=$(echo "$OUT" | jq -r .exists)
+  [ "$EXISTS" = "false" ] && { report_missing; exit 1; }
+  [ "$STATE" = "idle" ] && break
+  sleep 1
+done
+
+# 4. send brief — 两步：先用命名 buffer paste，再单独 Enter
+#
+#    重点: tmux load-buffer 的 -t 是 target-CLIENT（man tmux），不是 session/window。
+#    不要写 `tmux load-buffer -t $SESSION file`，那是把 session 名当 client 名传，
+#    行为不可靠（≥ 3.x 上要么 silently 落到默认 client，要么直接报错）。
+#    正确做法：用命名 buffer（-b <name>），完全绕开 -t 歧义，也避免污染默认 buffer 栈。
+cat > "$BRIEF_FILE" <<'EOF'
+issue #42: ...多行 brief 内容...
+EOF
+ssh "$MACHINE" "cat > /tmp/brief.txt" < "$BRIEF_FILE"
+ssh "$MACHINE" "tmux load-buffer -b cc-brief /tmp/brief.txt \
+                && tmux paste-buffer -b cc-brief -t ${SESSION}:${WINDOW} \
+                && tmux delete-buffer -b cc-brief"
+sleep 0.3
+ssh "$MACHINE" "tmux send-keys -t ${SESSION}:${WINDOW} Enter"
+
+# 5. poll loop — 每 N 秒 capture + classify，落 prev_state 状态机。
+#    capture() 把 missing / capture_failed 直接出在 JSON 里，classify() 只见
+#    "存在且能截到"的 pane，所以 case 里 missing / capture_failed 走独立分支。
+#    DEAD_STREAK 让调度方对 dead 做 stability 收敛 — 单次 dead 不动作，
+#    避免误报触发重启撞上 trust-prompt / 启动中的 CC（hard rule #8）。
+PREV=busy
+DEAD_STREAK=0
+while true; do
+  OUT=$(ssh "$MACHINE" "tmux capture-pane -t ${SESSION}:${WINDOW} -p -S -200" \
+        | PREV_STATE=$PREV python3 poll.py)
+  EXISTS=$(echo "$OUT" | jq -r .exists)
+  CAPTURE_OK=$(echo "$OUT" | jq -r .capture_ok)
+  STATE=$(echo "$OUT" | jq -r .state)
+
+  if [ "$EXISTS" = "false" ]; then report_missing; break; fi
+  if [ "$CAPTURE_OK" = "false" ]; then sleep 5; continue; fi   # tmux race, retry
+
+  case "$STATE" in
+    busy)                DEAD_STREAK=0 ;;                              # 继续等
+    awaiting_permission) report_to_owner; break ;;                    # 上报，不代选
+    error)               report_error; break ;;
+    dead)
+      DEAD_STREAK=$((DEAD_STREAK + 1))
+      [ "$DEAD_STREAK" -ge 3 ] && { report_dead; break; }             # 3 连 dead 才动手
+      ;;
+    done_unread)         harvest_capture; break ;;                    # 收尾，写 receipt
+    idle)                DEAD_STREAK=0 ;;                             # idle 是 catch-all，重置计数
+  esac
+  PREV=$STATE
+  sleep 30
+done
+```
+
+不要把上面这段封进 helper 库 — 每次调用方按自己的状态机（butler ledger / cron poller / 其他）现场拼。封装的成本是丢弃灵活性 + 引入版本漂移。SOP 才是产出物。
+
+## 已知坑
+
+1. tmux load-buffer -t 是 target-CLIENT，不是 session/window — 这是最常犯的错。`tmux load-buffer -t jack file` 是把 "jack" 当 client 名传，不是 session 名。正确用法：省掉 `-t`（默认 buffer），或用命名 buffer：`tmux load-buffer -b cc-brief file && tmux paste-buffer -b cc-brief -t SESSION:WINDOW && tmux delete-buffer -b cc-brief`。命名 buffer 更好，避免污染默认 buffer 栈。
+2. tmux send-keys 提交多行 input — 用 `load-buffer + paste-buffer + 单独 Enter`，不要 `send-keys "$(cat brief.txt)" Enter`。后者把内嵌 \n 当 Enter，CC 输入框会断成多个不完整 prompt。
+3. capture-pane 默认只截可见区域 — 必须 `-S -200`（或更大）取 history。CC TUI 滚屏快，不取 history 容易 miss spinner 行。
+4. ANSI 不剥不要 grep — CC TUI 大量 SGR 序列把 "esc to interrupt" 切成片段，正则全 miss。先 sanitize 再 classify。
+5. spinner 词表会随 CC 版本扩 — 上面 SPINNER_RE 是 2026-03 的快照，发现新词加进去，不要假定枚举完整。busy 的兜底判据是 `esc to interrupt` 这串字符，比 spinner 词更稳。
+6. SSH ControlMaster 跟 tmux 不冲突，但跟"tmux 跑在本地套 ssh"那种错用法叠加会让症状更迷惑（断连后 mux 还假装活着）。一律按 hard rule #1 走。
+7. status-line / vim-airline 之类装饰会让同一信息每秒刷新，sanitize 必须做"连续相同行去重"，否则 last-N-lines 全是 status-line 噪音。
+8. CC 启动如果遇到未授权目录 / sandbox prompt，会卡在一个非 TUI 的"是否信任此目录"提问 — 这种情况判定函数会落 `idle`（catch-all，因为不满足 dead 的积极证据），调度方需要单独有"trust prompt" 探测（grep `Do you trust the files` / `trust this directory` 之类），本 skill 的 classify 不覆盖这条边界。
+9. window name 含特殊字符（`/`, `:`, 空格）会让 `tmux ... -t session:window` 解析失败。命名时只用 `[A-Za-z0-9_-]`。
+10. `tmux has-session` 在远程返回 "no server running" 是正常的（第一次 spawn），按 idempotent 处理，不要把它当 error。
+11. `--append-system-prompt` vs `--system-prompt` — append 保留 CC 的工具能力，replace 会把工具描述也覆盖掉导致 CC 不会调用 tool。executor 隔离用 append，不要用 replace。
+
+## Non-goals
+
+- 不提供 bash/python 脚本封装。SOP 是产出物，调用方自己抄。封装会丢弃针对不同调度场景调整的灵活性。
+- 不管 dispatch ledger / receipt 格式 / 状态机持久化 — 那是 butler 等调用方的职责，本 skill 只暴露 5 个 stateless primitive。
+- 不管"哪台 executor 该接哪个 brief" 的路由决策 — 那是 routing 层，不是 ops 层。
+- 不负责 brief 的语义内容 / 模板 / warmup 句注入 — 那是 dispatcher 的事，本 skill 只管 byte-level 送达。
+- 不替用户做权限决策（hard rule #5）。awaiting_permission 永远是上报，不是自动放行。
+- 不覆盖 trust-this-directory 的 sandbox prompt（已知坑 #8），调用方需要在 spawn 时用 `--allow-all-paths` 或预先 trust。

--- a/claude/skills/tmux-cc-ops/SKILL.md
+++ b/claude/skills/tmux-cc-ops/SKILL.md
@@ -99,54 +99,20 @@ tmux kill-window -t ${SESSION}:${WINDOW}
 
 ## CC 状态判定
 
-从 capture-pane 输出判断 CC 在做什么：
+`tmux capture-pane -t ${SESSION}:${WINDOW} -p -S -20 | tail -10` 看输出判断：
 
-| state | 判据（sanitized tail ~80 行，顺序 match） |
+| 看到什么 | CC 在做什么 |
 |---|---|
-| starting | 出现 `Welcome to Claude Code` / `Loading…` / `Initializing`，且无 TUI box 字符 |
-| busy | last5 含 `esc to interrupt`，或 spinner 词（Cogitating/Thinking/Working 等）+ `…` |
-| awaiting_permission | tail 同时含 `Do you want to`/`Allow` + 编号选项 `1.` + `esc to cancel` |
-| error | tail[-10:] 含 `panic:` / `Traceback` / `^API Error`，且 has_tui=True |
-| done_unread | has_tui=True + idle 视觉判据 + `prev_state == busy` |
-| idle | TUI 输入框特征（`│ > ` / `╰─` / `? for shortcuts`），或证据不足的 catch-all |
-| dead | 积极证据全满足：shell prompt 在末行 + capture 非空 + prev_state 不在 busy/starting |
+| spinner 词（Thinking/Working/Cogitating...）+ `esc to interrupt` | 在跑，等着 |
+| `Do you want to` + 编号选项 + `esc to cancel` | 等权限确认，上报 owner |
+| `❯ ` 提示符，无 spinner | idle，可以发指令 |
+| `Welcome to Claude Code` / `Loading` | 正在启动 |
+| `panic:` / `Traceback` / `API Error` | 出错了 |
+| shell `$` / `%` 提示符，无 CC TUI | CC 已退出 |
 
-调度方语义层：`missing`（`exists=False`）、`capture_failed`（`exists=True, capture_ok=False`）不进 classify。
+也可以用 pane_title 快速预判：`tmux display-message -p -t ${SESSION}:${WINDOW} "#{pane_title}"` — 首字符是 braille 旋转动画 = busy，✳ = idle。注意 CC crash 后 pane_title 可能保留旧值，需配合 capture-pane 确认。
 
-classify 实现要点：
-- 输入必须是 sanitized text，接受 `prev_state` 参数
-- catch-all 是 `idle` 不是 `dead`；`dead` 必须严格按积极证据返回
-- 函数必须 pure，无 side effect
-
-## Worked example: spawn → brief → poll → harvest
-
-```bash
-MACHINE=116; SESSION=jack; WINDOW="42-pr-review"
-# 1. spawn（在远端开窗，不是本地）
-ssh "$MACHINE" "tmux has-session -t $SESSION 2>/dev/null || tmux new-session -d -s $SESSION"
-ssh "$MACHINE" "tmux new-window -t ${SESSION}: -n ${WINDOW} && cd /tmp && claude"
-
-# 2. send brief（两步：paste + 单独 Enter；用命名 buffer 避免 -t 歧义）
-ssh "$MACHINE" "cat > /tmp/brief-${WINDOW}.txt" < brief.txt
-ssh "$MACHINE" "tmux load-buffer -b cc-brief /tmp/brief-${WINDOW}.txt \
-  && tmux paste-buffer -b cc-brief -t ${SESSION}:${WINDOW} \
-  && tmux delete-buffer -b cc-brief"
-sleep 0.3 && ssh "$MACHINE" "tmux send-keys -t ${SESSION}:${WINDOW} Enter"
-
-# 3. poll loop（prev_state 驱动状态机，dead streak 防误报）
-PREV=busy; DEAD_STREAK=0
-while true; do
-  STATE=$(ssh "$MACHINE" "tmux capture-pane -t ${SESSION}:${WINDOW} -p -S -200" | PREV_STATE=$PREV python3 poll.py | jq -r .state)
-  case "$STATE" in
-    busy)                DEAD_STREAK=0 ;;
-    awaiting_permission) report_to_owner; break ;;
-    done_unread)         harvest_capture; break ;;
-    dead) DEAD_STREAK=$((DEAD_STREAK+1)); [ $DEAD_STREAK -ge 3 ] && { report_dead; break; } ;;
-    idle) DEAD_STREAK=0 ;;
-  esac
-  PREV=$STATE; sleep 30
-done
-```
+关键原则：不确定时当 idle 处理，不要猜 dead。dead 需要看到 shell 提示符等积极证据。
 
 ## 已知坑
 

--- a/claude/skills/tmux-cc-ops/SKILL.md
+++ b/claude/skills/tmux-cc-ops/SKILL.md
@@ -67,10 +67,33 @@ done
 | pane_title 首字符 | 判定 |
 |---|---|
 | braille (U+2800–U+28FF) | busy |
-| ✳ (U+2733) | idle |
-| 其他 / 空 | 降级到 capture + classify |
+| ✳ (U+2733) | idle — 但须配合 statusline 检查（见下方） |
+| hostname / 普通文本 | starting（trust-this-directory 阶段，CC TUI 尚未就绪） |
+| 空 / 空白 | CC 已退出（dead），配合 capture-pane 确认 shell 提示符 |
+| 其他 | 降级到 capture + classify |
 
-注意：CC 异常退出后 pane_title 可能保留旧值，不能单独依赖，需配合 capture-pane 二次确认。
+注意：CC 完成任务后 pane_title 可能短暂保留 braille 旧值，过几秒后才更新为 ✳。不能单独依赖 pane_title，需配合 capture-pane + statusline 确认。
+
+### ✳ 时必须检查 statusline — background shell/agent 场景
+
+看到 ✳ (idle) 时，还需检查 statusline 最后两行是否含 `shell` 或 `agents` / `local agent` 关键词：
+
+```bash
+# 抓 statusline（最后 2 行含 status bar 内容）
+tmux capture-pane -t {session}:{window} -p -S -2 | tail -2
+```
+
+| statusline 含什么 | 实际状态 |
+|---|---|
+| 无 `shell` / `agents` / `local agent` | 真 idle，可以发指令 |
+| `· N shell` 或 `· N shells` | background shell 在跑，主 CC idle 但有子进程未完成 |
+| `· N local agent` 或 `· N local agents` | background sub-agent 在跑，主 CC idle 但 agent 未完成 |
+
+实测证据（jackon.me butler session，2026-04-09）：
+- `butler:wiki-scout`：pane_title=✳，statusline=`⏵⏵ bypass permissions on · 1 shell`，实际有 shell 后台运行
+- `butler:claude`：pane_title=✳，statusline=`⏵⏵ bypass permissions on · 1 local agent`，实际有 sub-agent 在跑
+
+判定规则：pane_title=✳ 且 statusline 无 shell/agents → `idle`；有 shell/agents → `background_busy`（不能派新任务）。
 
 ## 常用命令速查
 
@@ -105,14 +128,16 @@ tmux kill-window -t ${SESSION}:${WINDOW}
 |---|---|
 | spinner 词（Thinking/Working/Cogitating...）+ `esc to interrupt` | 在跑，等着 |
 | `Do you want to` + 编号选项 + `esc to cancel` | 等权限确认，上报 owner |
-| `❯ ` 提示符，无 spinner | idle，可以发指令 |
+| `❯ ` 提示符，无 spinner，statusline 无 shell/agents | idle，可以发指令 |
+| `❯ ` 提示符，但 statusline 含 `· N shell` 或 `· N local agent` | background busy — 主 CC idle 但有子进程/sub-agent 未完成，不能派新任务 |
 | `Welcome to Claude Code` / `Loading` | 正在启动 |
+| trust-this-directory 选项框（非 CC TUI，pane_title=hostname） | 启动阶段等确认，需发 Enter 或传 `--dangerously-skip-permissions` |
 | `panic:` / `Traceback` / `API Error` | 出错了 |
-| shell `$` / `%` 提示符，无 CC TUI | CC 已退出 |
+| shell `$` / `%` 提示符，无 CC TUI，pane_title 为空 | CC 已退出 |
 
-也可以用 pane_title 快速预判：`tmux display-message -p -t ${SESSION}:${WINDOW} "#{pane_title}"` — 首字符是 braille 旋转动画 = busy，✳ = idle。注意 CC crash 后 pane_title 可能保留旧值，需配合 capture-pane 确认。
+也可以用 pane_title 快速预判：`tmux display-message -p -t ${SESSION}:${WINDOW} "#{pane_title}"` — 首字符是 braille 旋转动画 = busy，✳ = idle（但需配合 statusline 排除 background busy，见上方"✳ 时必须检查 statusline"），空 = dead。注意 CC crash 后 pane_title 可能保留旧值，需配合 capture-pane 确认。
 
-关键原则：不确定时当 idle 处理，不要猜 dead。dead 需要看到 shell 提示符等积极证据。
+关键原则：不确定时当 idle 处理，不要猜 dead。dead 需要看到 shell 提示符 + pane_title 为空等积极证据。
 
 ## 已知坑
 

--- a/claude/skills/tmux-cc-ops/SKILL.md
+++ b/claude/skills/tmux-cc-ops/SKILL.md
@@ -18,15 +18,37 @@ tmux + Claude Code 操控 SOP。给调度器（butler 等）做远程/本地 CC 
 通用方法：split-window N-1 次 → `select-layout tiled` 自动排列。
 
 ```bash
-# 2×3 = 6 pane: 1 原始 + 5 次 split → tiled
-for i in $(seq 1 5); do tmux split-window -t ${SESSION}:${WINDOW}; done
+# 通用：N pane = 1 原始 + (N-1) 次 split → tiled
+for i in $(seq 1 $((N-1))); do tmux split-window -t ${SESSION}:${WINDOW}; done
 tmux select-layout -t ${SESSION}:${WINDOW} tiled
-
-# 2×4 = 8 pane: 1 原始 + 7 次 split → tiled
-# 3×3 = 9 pane: 1 原始 + 8 次 split → tiled
 ```
 
 远程：每条 tmux 命令前加 `ssh "$MACHINE"`。tiled 根据终端尺寸自动选行列比，宽屏接近 RxC，窄屏可能变形，可接受。
+
+### 常用场景：2×3 监控 6 个 executor
+
+```bash
+# 在 101 上开 6 pane 监控面板，每个 pane 跑一个 CC executor
+SESSION=jwork; WINDOW=monitor; MACHINE=101
+
+# 开窗 + split 成 6 pane
+ssh $MACHINE "tmux new-window -t ${SESSION}: -n ${WINDOW}"
+for i in $(seq 1 5); do ssh $MACHINE "tmux split-window -t ${SESSION}:${WINDOW}"; done
+ssh $MACHINE "tmux select-layout -t ${SESSION}:${WINDOW} tiled"
+
+# 每个 pane 里启动一个任务（pane 编号 0-5）
+TASKS=("tilert-ci" "debug-54" "debug-49" "pe-audit" "sim-test" "cleanup")
+DIRS=("TileRT4AICA" "aica-lab" "aica-lab" "AICASimPlatform" "AICASimPlatform" "aica-lab")
+for i in $(seq 0 5); do
+  ssh $MACHINE "tmux send-keys -t ${SESSION}:${WINDOW}.${i} \
+    'cd ~/workspace-2026/${DIRS[$i]} && claude --dangerously-skip-permissions' Enter"
+done
+
+# attach 进去看：ssh 101 → tmux attach -t jwork:monitor
+# F11 zoom 单个 pane 操作，再 F11 回 grid
+```
+
+快速触发：`ssh 101 "tmux select-window -t jwork:monitor"` 切到监控面板。鼠标点击切 pane，F11 zoom/unzoom。
 
 ## Hard Rules
 

--- a/claude/skills/tmux-cc-ops/SKILL.md
+++ b/claude/skills/tmux-cc-ops/SKILL.md
@@ -20,11 +20,27 @@ tmux + Claude Code 操控的 SOP。给调度器（butler 等）做远程/本地 
 2. spawn CC 时必须切到隔离 cwd，并显式 `--append-system-prompt` 注入"本会话是 executor，照 brief 干活，不要受 cwd CLAUDE.md 里 protocol 词汇拐走"。否则远端 CLAUDE.md（waypoint / jack-vault 等）会立刻把新会话拽进特定 role，brief 失效。
 3. send-keys 提交 prompt 必须是两步：先 paste 文本（literal mode），再单独发一次 `Enter`。一步走 `send-keys "text" Enter` 在多行 brief 上会被解释成 `text\n` 而不是"提交输入框"，CC 会收到一个不完整 prompt。
 4. 状态判定只能基于 sanitized capture-pane 输出（去 ANSI、去 status-line 噪音、保留最后 N 行），不准基于 exit code、tmux pane status、或脑补的时序。判定函数错杀 = 调度系统幻觉。
-5. 永远不替用户决策权限弹窗。识别到 `awaiting_permission` → 上报，不准盲发数字键。教训：jack-vault `sop-1-control-n.md` 记录的 2026-03-21 home-reno 事故。
+5. 永远不替用户决策权限弹窗。识别到 `awaiting_permission` → 上报，不准盲发数字键。绝对禁止向多个 window 盲发 y/Enter — 必须先 capture-pane 确认是权限弹窗（含 Yes/No + esc to cancel）才放行。教训：jack-vault `sop-1-control-n.md` 记录的 2026-03-21 home-reno 事故 — 盲发 y 导致 3 个 window 的决策被自动选 A。
 6. 同一 (machine, session, window) 不允许并发两个 brief。送 brief 之前必须先 classify，确认是 `idle` 或 `done_unread` 才能送，否则会跟前一个任务的 input 撞车。
 7. 远程操作走 `ssh X 'tmux ...'`，每条命令是独立 ssh exec，不维持长连接。短连接 ssh 控制层是稳定的；长连接交互 shell 是不稳定的（参见规则 1）。
 8. `dead` 必须有积极证据，单纯 not-has-tui 不构成 dead 判据。积极证据 = last non-empty line 命中 shell prompt 正则 + capture 非空 + 不是刚从 `busy` / `starting` 跳出来（这些状态有几帧 TUI 缺失是正常的）。证据不足时 catch-all 落 `idle`，让调度方靠多次 poll 的 stability 计数把"持续 idle 但其实是 trust prompt 或 dead pane"的边界 case 收敛掉。误报 dead 会触发"重起 executor"路径，撞上正在启动的 CC、trust-this-directory prompt（已知坑 #7）、或 capture race，直接破坏 owner 介入窗口。
 9. `missing` 是 `capture` primitive 的结构化返回字段，不是 `classify` 的返回值。window/session 不存在 → `capture(...)` 返回 `exists=False`，调用方据此决定是否要 spawn。`classify` 只在 `exists=True && capture_ok=True` 时被调用，只负责"已经在那里、能截到的 pane"的视觉判定。混淆这两个责任会让 classify 用空字符串或 stderr 当输入猜状态，必然误判。
+
+## pane_title 状态判定
+
+CC 通过 OSC 转义序列设置终端标题，tmux 自动捕获为 `pane_title`。用它做首轮 busy/idle 判定比纯 capture-pane regex 更可靠 — background agent 运行时 capture-pane 可能显示 `❯` 误判为 idle，但 pane_title 的首字符不会撒谎。
+
+```bash
+tmux display-message -p -t {session}:{window} "#{pane_title}"
+```
+
+判定规则（首轮快速判断）：
+
+- 首字符是 braille (U+2800–U+28FF) → busy（CC 在跑，旋转动画）
+- 首字符是 ✳ (U+2733) → idle
+- 其他 / 空 → 不确定，降级到 capture-pane + classify 做二次确认
+
+推荐用法：先查 `pane_title` 做轻量预判；当 pane_title 不确定或需要更细粒度状态（done_unread、awaiting_permission 等）时，再走完整 capture + classify 流程。两者互补，不是替代关系。
 
 ## Contract
 
@@ -236,6 +252,30 @@ def classify(sanitized_text: str, prev_state: str | None = None) -> str:
 - `missing` 不在 classify 输出集 — 调用方先调 `capture()`，根据 `exists` 字段判 missing；classify 的输入永远来自 `capture_ok=True` 的分支。
 - 不要在判定函数里做 side effect（不发 send-keys、不写日志），它必须 pure，方便单元测试用 fixture 喂。
 
+## 多 executor 布局：2 行 3 列 grid
+
+需要同时跑多个 executor 并肉眼监控时，tiled 布局最省事：
+
+```bash
+SESSION=jack
+WINDOW="executor-pool"
+
+# 先确保 window 存在
+ssh "$MACHINE" "tmux new-window -t ${SESSION}: -n ${WINDOW}"
+
+# 再 split 5 次 = 共 6 panes
+ssh "$MACHINE" "tmux split-window -t ${SESSION}:${WINDOW}"
+ssh "$MACHINE" "tmux split-window -t ${SESSION}:${WINDOW}"
+ssh "$MACHINE" "tmux split-window -t ${SESSION}:${WINDOW}"
+ssh "$MACHINE" "tmux split-window -t ${SESSION}:${WINDOW}"
+ssh "$MACHINE" "tmux split-window -t ${SESSION}:${WINDOW}"
+
+# tiled 自动排成 2x3 grid
+ssh "$MACHINE" "tmux select-layout -t ${SESSION}:${WINDOW} tiled"
+```
+
+注意：pane 数不是 6 的整数倍时，tiled 会做不均匀切分，视觉上最后一列可能只有 1 行。可以接受，调度层不感知 pane 布局。
+
 ## Worked example: spawn → brief → poll → harvest
 
 butler 收到 dispatch `consumer.kind=tmux_window`, target 机器 116, brief 是 "去把 issue #42 的 PR review 走完"。下面是端到端 SOP（每行调用方现场抄）。
@@ -330,6 +370,22 @@ done
 9. window name 含特殊字符（`/`, `:`, 空格）会让 `tmux ... -t session:window` 解析失败。命名时只用 `[A-Za-z0-9_-]`。
 10. `tmux has-session` 在远程返回 "no server running" 是正常的（第一次 spawn），按 idempotent 处理，不要把它当 error。
 11. `--append-system-prompt` vs `--system-prompt` — append 保留 CC 的工具能力，replace 会把工具描述也覆盖掉导致 CC 不会调用 tool。executor 隔离用 append，不要用 replace。
+12. iTerm2 CC 集成模式（`-CC` 标志）会破坏 dashboard 布局 — 开了 `-CC` 后 iTerm2 会接管 tmux 的 pane 渲染，`select-layout tiled` 失效，capture-pane 输出也会带额外元数据。调度脚本不要在 `-CC` 模式下跑。
+13. capture-pane 误判 CC idle 状态 — background agent 运行时 pane 末尾可能显示 `❯` 提示符，但 CC 实际仍在运行。应优先用 `pane_title` 首字符（braille = busy，✳ = idle）做首轮判断，capture-pane 降级为二次确认。见 pane_title 状态判定 section。
+14. 并行 claude -p 上限约 4 — CC issue #24990 记录了超过 4 个并发 `-p` 进程时出现 token 争用导致 hang 的问题。executor pool 上限保守设 4，超出时让新任务排队等 idle slot，不要无限 spawn。
+15. agent hang 无超时 — CC 不提供内建的任务超时机制（CC bug #28482）。调度方必须在外层实现 kill 机制：记录 `started_at`，poll 时判断 `now - started_at > threshold` 则强制 `tmux kill-pane` 后重起。阈值根据任务类型自定，建议 10–30 分钟。
+
+## 快捷片段
+
+### ctx% 快速读取
+
+从 pane 末行抓 CC 当前 context 使用百分比（用于调度方判断"是否快 ctx 满了"）：
+
+```bash
+tmux capture-pane -t {session}:{window} -p -S -1 | grep -oP 'ctx:\K\d+(?=%)'
+```
+
+输出示例：`73`（表示 73% context 已用）。抓不到（CC 未显示 ctx% 行）时输出空，调度方按"未知"处理。
 
 ## Non-goals
 

--- a/claude/skills/tmux-cc-ops/SKILL.md
+++ b/claude/skills/tmux-cc-ops/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tmux-cc-ops
-description: Primitives for spawning, prompting, capturing, and state-classifying remote/local Claude Code sessions running inside tmux windows. Use when a scheduler/butler needs to operate CC sessions as worker pool — spawn on (machine, session, window), send a brief, poll pane to decide idle / busy / awaiting-permission / done-unread / dead. Not for interactive single-session use.
+description: Primitives for spawning, prompting, capturing, and state-classifying remote/local Claude Code sessions running inside tmux windows. Use when a scheduler/butler needs to operate CC sessions as worker pool — spawn on (machine, session, window), send a brief, poll pane to decide idle / busy / awaiting_permission / done-unread / dead. Not for interactive single-session use.
 ---
 
 # tmux-cc-ops
@@ -215,8 +215,12 @@ def classify(sanitized_text: str, prev_state: str | None = None) -> str:
     has_tui = ("│ >" in tail) or ("? for shortcuts" in tail) or ("╰─" in tail)
 
     if has_tui:
+        # has_tui is a coarse guard — error keywords anywhere in the 80-line tail
+        # can false-positive when a tool prints "API Error" while TUI is still up.
+        # This check is intentionally conservative (prefer idle over false error).
+        # Callers must NOT use "error" state to trigger destructive operations.
         if re.search(r"panic:|Traceback \(most recent call last\)|^API Error",
-                     tail, re.MULTILINE):
+                     tail[-10:], re.MULTILINE):
             return "error"
         if prev_state == "busy":
             return "done_unread"

--- a/claude/skills/tmux-cc-ops/SKILL.md
+++ b/claude/skills/tmux-cc-ops/SKILL.md
@@ -1,17 +1,18 @@
 ---
 name: tmux-cc-ops
-description: Primitives for spawning, prompting, capturing, and state-classifying remote/local Claude Code sessions running inside tmux windows. Use when a scheduler/butler needs to operate CC sessions as worker pool — spawn on (machine, session, window), send a brief, poll pane to decide idle / busy / awaiting_permission / done-unread / dead. Not for interactive single-session use.
+description: Primitives for managing tmux windows with Claude Code sessions — spawn, send prompts, capture output, classify state, build grid layouts. Use when you need to run multiple CC sessions, monitor their status, or operate remote executors.
 ---
 
 # tmux-cc-ops
 
-tmux + Claude Code 操控 SOP。给调度器（butler 等）做远程/本地 CC executor 池用。本身不提供脚本封装，调用方按 SOP 现写 bash/Python。
+tmux + Claude Code 操控 SOP。管理本地和远程的 CC session — 开窗、送 prompt、看状态、布局监控面板。
 
 ## Triggers
 
-- 调度器要 spawn 新 CC executor（local 或远程）
-- 已有 tmux window 需要 poll 状态
-- `consumer.kind=tmux_window` 的 dispatch 需要落地
+- 需要同时跑多个 CC session（本地或远程）
+- 需要 poll 某个 tmux window 里 CC 的状态
+- 需要给远程机器开 CC session 跑任务
+- 需要搭建多 pane 监控面板
 
 ## 任意 N pane grid 布局
 
@@ -52,10 +53,10 @@ done
 
 ## Hard Rules
 
-1. tmux server 必须跑在 executor 机器上，不是 butler 本地。远程 executor = `ssh X → tmux new-window → claude`，禁止 `本地 tmux → ssh X → claude`。原因：后者 SSH 断则 CC 收 SIGHUP 退出，executor 寿命跟 butler session 绑死。
+1. 远程 executor 的 tmux 必须跑在远程机器上：`ssh X → tmux new-window → claude`。禁止 `本地 tmux → ssh X → claude`（SSH 断则 CC 收 SIGHUP 退出）。本地操作无此限制。
 2. 状态判定只能基于 sanitized capture-pane 输出（去 ANSI、去 status-line 噪音、保留最后 N 行），不准基于 exit code 或脑补时序。
 3. 永远不替用户决策权限弹窗。识别到 `awaiting_permission` → 上报，禁止盲发数字键。必须先 capture-pane 确认含 Yes/No + `esc to cancel` 才放行。
-4. 同一 `(machine, session, window)` 不允许并发两个 brief。送 brief 前先 classify 确认是 `idle` 或 `done_unread`。
+4. 同一 window 不允许并发两个 brief。送 brief 前先 classify 确认是 `idle` 或 `done_unread`。
 5. 远程操作走 `ssh X 'tmux ...'`，每条命令独立 ssh exec，不维持长连接。
 6. `dead` 必须有积极证据：last non-empty line 命中 shell prompt 正则 + capture 非空 + `prev_state not in (busy, starting)`。证据不足落 `idle`。
 
@@ -155,4 +156,4 @@ done
 
 ## Non-goals
 
-- 不管 dispatch ledger / receipt 格式；不做路由决策；不管 brief 语义内容；不替用户做权限决策（hard rule #3）；不覆盖 trust-this-directory sandbox prompt。
+- 不做路由决策（哪个任务发给哪台机器）；不管 prompt 怎么写；不替用户做权限决策（hard rule #3）；不覆盖 trust-this-directory sandbox prompt。

--- a/claude/skills/tmux-cc-ops/SKILL.md
+++ b/claude/skills/tmux-cc-ops/SKILL.md
@@ -72,23 +72,34 @@ done
 
 注意：CC 异常退出后 pane_title 可能保留旧值，不能单独依赖，需配合 capture-pane 二次确认。
 
-## Contract：5 个原子操作
+## 常用命令速查
 
-target 三元组：`(machine, session, window)`，machine = `"local"` 或 ssh host。
+```bash
+# 开窗 + 启动 CC
+tmux new-window -t ${SESSION}: -n ${WINDOW}
+tmux send-keys -t ${SESSION}:${WINDOW} "cd ${CWD} && claude --dangerously-skip-permissions" Enter
 
-| op | 输入 | 输出 |
-|---|---|---|
-| spawn_window | target, cwd | target（已起 claude） |
-| send_brief | target, brief_text | — |
-| capture | target, lines=200 | `{exists, capture_ok, text, stderr}`（text 已 sanitize） |
-| classify_state | sanitized text, prev_state | state enum（仅在 `exists && capture_ok` 时调用） |
-| kill_window | target | — |
+# 发指令（简单文本直接 send-keys）
+tmux send-keys -t ${SESSION}:${WINDOW} '你的指令' Enter
 
-调度方自己持久化 `(target → last_state, last_capture_hash, last_state_at)`。
+# 发多行 brief（用命名 buffer 避免换行问题）
+tmux load-buffer -b brief-${WINDOW} /tmp/brief-${WINDOW}.txt
+tmux paste-buffer -b brief-${WINDOW} -t ${SESSION}:${WINDOW}
+tmux delete-buffer -b brief-${WINDOW}
+sleep 0.3 && tmux send-keys -t ${SESSION}:${WINDOW} Enter
 
-## State enum
+# 看状态
+tmux capture-pane -t ${SESSION}:${WINDOW} -p -S -20 | tail -10
 
-`capture()` 负责 "pane 在不在"，返回 `{exists, capture_ok, text, stderr}`。`exists=False` = `missing`，不进 classify。`classify()` 只在 `exists=True && capture_ok=True` 时调用。
+# 关窗
+tmux kill-window -t ${SESSION}:${WINDOW}
+```
+
+远程：命令前加 `ssh $MACHINE "..."`。
+
+## CC 状态判定
+
+从 capture-pane 输出判断 CC 在做什么：
 
 | state | 判据（sanitized tail ~80 行，顺序 match） |
 |---|---|

--- a/claude/skills/tmux-cc-ops/SKILL.md
+++ b/claude/skills/tmux-cc-ops/SKILL.md
@@ -89,11 +89,7 @@ tmux capture-pane -t {session}:{window} -p -S -2 | tail -2
 | `· N shell` 或 `· N shells` | background shell 在跑，主 CC idle 但有子进程未完成 |
 | `· N local agent` 或 `· N local agents` | background sub-agent 在跑，主 CC idle 但 agent 未完成 |
 
-实测证据（jackon.me butler session，2026-04-09）：
-- `butler:wiki-scout`：pane_title=✳，statusline=`⏵⏵ bypass permissions on · 1 shell`，实际有 shell 后台运行
-- `butler:claude`：pane_title=✳，statusline=`⏵⏵ bypass permissions on · 1 local agent`，实际有 sub-agent 在跑
-
-判定规则：pane_title=✳ 且 statusline 无 shell/agents → `idle`；有 shell/agents → `background_busy`（不能派新任务）。
+判定：pane_title=✳ 且 statusline 无 shell/agents → `idle`；有 shell/agents → `background_busy`（不能派新任务）。
 
 ## 常用命令速查
 


### PR DESCRIPTION
## Summary

- Adds `claude/skills/tmux-cc-ops/SKILL.md` — SOP for operating tmux-based Claude Code executor pools (spawn, send brief, capture, classify state, kill)
- Fixes 2 HIGH issues from the earlier PR #27 draft (branch feat/31-tmux-cc-ops)

## Fixes

**HIGH #1 — classifier catch-all was `dead`**
The previous draft returned `dead` as the default when no TUI was detected. This triggers scheduler "restart executor" paths on any ambiguous capture (trust-prompt, race, transient blank, post-busy frame). Fixed: catch-all is now `idle`. `dead` requires all three positive evidence conditions: shell prompt at end of last non-empty line + non-trivial capture size + `prev_state not in (busy, starting)`.

**HIGH #2 — `tmux load-buffer -t` wrong syntax**
`tmux load-buffer -t SESSION` passes a session name where tmux expects a *client* name (`-t` is target-client in `load-buffer`, not target-session). Fixed: use named buffer (`-b cc-brief`) throughout — `load-buffer -b cc-brief file && paste-buffer -b cc-brief -t SESSION:WINDOW && delete-buffer -b cc-brief`. This is both correct and avoids polluting the default buffer stack.

## Test plan

- [ ] Read through the State enum section and verify `idle` is the catch-all in the code skeleton
- [ ] Verify `classify()` docstring explicitly calls out "catch-all is idle, not dead"
- [ ] Verify worked example step 4 uses `-b cc-brief` with no `-t SESSION` on `load-buffer`
- [ ] Verify known-pit #1 explains the -t client vs session distinction

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)