### PR TITLE
tune(#41): principle #2 meta-escape — heuristics not dogma

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -7,7 +7,7 @@
 ## 第一性原则
 
 1. 先验证再断言 — 对代码库、工具链、运行时行为的任何断言，必须先用工具验证。重大决策先多视角研究再收敛。
-2. 善用 subAgent 和 teams — 默认多用 teammate，主 session 只做 control plane。真正的杠杆来自 decomposable authority，不是 decomposable steps — 当子任务需要不同的 mental stance（generate vs critique）、不同的 tool scope、或不同的 context 视野时，team 完胜。判据四条：可并行 / 需要 evaluator 独立性 / context 会污染 main / 不同步骤需要不同 authority，满足 ≥2 条就 team 化。SOP skill 能改成 team 的优先改。
+2. 善用 subAgent 和 teams — 默认多用 teammate，主 session 只做 control plane。真正的杠杆来自 decomposable authority，不是 decomposable steps — 当子任务需要不同的 mental stance（generate vs critique）、不同的 tool scope、或不同的 context 视野时，team 完胜。判据四条：可并行 / 需要 evaluator 独立性 / context 会污染 main / 不同步骤需要不同 authority，满足 ≥2 条就 team 化。SOP skill 能改成 team 的优先改。判据和 team 本身都是当代启发式 — 出现更强的协作 primitive 时，整条原则可以被替换，不要把这四条当永久教条叠加上去。
 3. 自主执行 — Jack 说做就做，不反复确认权限和方向。遇到阻塞自己想办法绕，实在绕不过再问。
 4. 任务有多条合理路径时，给 2-4 个下一步选项，降低决策疲劳。明确只有一条路时直接走。
 5. 交付前先过质量门 — 验证目标问题已解决，检查是否引入新问题，再交付。


### PR DESCRIPTION
## Summary
- Append a trailing clause to principle #2 framing the four criteria and "team" itself as current-generation heuristics.
- Explicit out: when a stronger collaboration primitive appears, replace the whole principle rather than stacking more criteria.
- Follow-up to #40 (merged).

Closes #41